### PR TITLE
Add Jest config and test for getAverageRating

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.5",
@@ -57,6 +58,9 @@
     "postcss-nested": "^7.0.2",
     "prisma": "^6.4.1",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.0"
   }
 }

--- a/src/lib/reviews/__tests__/getAverageRating.test.ts
+++ b/src/lib/reviews/__tests__/getAverageRating.test.ts
@@ -1,0 +1,35 @@
+import { getAverageRating } from '../getAverageRating';
+import { getDocs } from 'firebase/firestore';
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(),
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  getDocs: jest.fn(),
+}));
+
+const mockedGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
+
+describe('getAverageRating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns rounded average rating', async () => {
+    const docs = [
+      { data: () => ({ rating: 5 }) },
+      { data: () => ({ rating: 4 }) },
+      { data: () => ({ rating: 5 }) },
+    ];
+    mockedGetDocs.mockResolvedValue({ docs } as any);
+    const avg = await getAverageRating('provider');
+    expect(avg).toBe(4.7);
+  });
+
+  it('returns null when there are no ratings', async () => {
+    mockedGetDocs.mockResolvedValue({ docs: [] } as any);
+    const avg = await getAverageRating('provider');
+    expect(avg).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest via `jest.config.js`
- add test script
- add Jest dev dependencies
- test `getAverageRating` with mocked Firestore

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414772b4bc8328b946ebb5b3f0f475