### PR TITLE
Fix API route authentication

### DIFF
--- a/src/app/api/_utils/withAuth.ts
+++ b/src/app/api/_utils/withAuth.ts
@@ -1,0 +1,14 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/authOptions'
+import { NextResponse } from 'next/server'
+
+export default function withAuth<T>(handler: (req: any, ...args: any[]) => Promise<Response | NextResponse> | Response | NextResponse) {
+  return async function(req: any, ...args: any[]) {
+    const session = await getServerSession(authOptions)
+    if (!session || !session.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    req.user = session.user
+    return handler(req, ...args)
+  }
+}

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getFirestore, collection, doc, getDocs, updateDoc } from 'firebase/firestore';
 import { initializeApp, getApps, getApp } from 'firebase/app';
 import { firebaseConfig } from '@/lib/firebase';
-import withAuth from '@/app/utils/withAuth';
+import withAuth from '@/app/api/_utils/withAuth';
 
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const db = getFirestore(app);

--- a/src/app/api/capture-payment/route.ts
+++ b/src/app/api/capture-payment/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { db } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
-import withAuth from '@/app/utils/withAuth';
+import withAuth from '@/app/api/_utils/withAuth';
 
 async function handler(req: NextRequest & { user: any }) {
   const schema = z.object({

--- a/src/app/api/create-checkout-session/route.ts
+++ b/src/app/api/create-checkout-session/route.ts
@@ -4,7 +4,7 @@ import { db } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { z } from 'zod';
 import { logActivity } from '@/lib/firestore/logging/logActivity';
-import withAuth from '@/app/utils/withAuth';
+import withAuth from '@/app/api/_utils/withAuth';
 
 const CheckoutSchema = z.object({
   bookingId: z.string().min(1),

--- a/src/app/api/disputes/open/route.ts
+++ b/src/app/api/disputes/open/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createDispute } from '@/lib/firestore/disputes/createDispute';
-import { getServerUser } from '@/lib/getServerUser';
+import withAuth from '@/app/api/_utils/withAuth';
 
-export async function POST(req: NextRequest) {
-  const user = await getServerUser();
-  if (!user) return new NextResponse('Unauthorized', { status: 401 });
+async function handler(req: NextRequest & { user: any }) {
+  const user = req.user;
 
   const { bookingId, reason } = await req.json();
   if (!bookingId || !reason) return new NextResponse('Missing data', { status: 400 });
@@ -17,3 +16,5 @@ export async function POST(req: NextRequest) {
 
   return new NextResponse('Dispute Created', { status: 200 });
 }
+
+export const POST = withAuth(handler);

--- a/src/app/api/promote-user/route.ts
+++ b/src/app/api/promote-user/route.ts
@@ -1,7 +1,7 @@
 import { db } from '@/lib/firebase';
 import { doc, updateDoc } from 'firebase/firestore';
 import { NextRequest, NextResponse } from 'next/server';
-import withAuth from '@/app/utils/withAuth';
+import withAuth from '@/app/api/_utils/withAuth';
 
 async function handler(req: NextRequest & { user: any }) {
   if (req.user.role !== "admin") return NextResponse.json({ error: "Forbidden" }, { status: 403 });

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,7 +1,7 @@
 import { db } from '@/lib/firebase';
 import { NextRequest, NextResponse } from 'next/server';
 import { collection, addDoc, Timestamp } from 'firebase/firestore';
-import withAuth from '@/app/utils/withAuth';
+import withAuth from '@/app/api/_utils/withAuth';
 
 async function handler(req: NextRequest & { user: any }) {
   const { bookingId, reviewedId, text, rating } = await req.json();

--- a/src/app/api/services/route.js
+++ b/src/app/api/services/route.js
@@ -1,7 +1,7 @@
 import { db } from '@/lib/firebase';
 import { collection, addDoc, updateDoc, deleteDoc, doc, getDocs } from 'firebase/firestore';
 import { NextResponse } from 'next/server';
-import withAuth from '@/app/utils/withAuth';
+import withAuth from '@/app/api/_utils/withAuth';
 
 // GET all services
 async function getServices() {

--- a/src/app/api/stripe/connect/route.ts
+++ b/src/app/api/stripe/connect/route.ts
@@ -2,15 +2,14 @@ import { NextResponse } from 'next/server'
 import Stripe from 'stripe'
 import { db } from '@/lib/firebase'
 import { doc, setDoc } from 'firebase/firestore'
-import { getServerUser } from '@/lib/auth/getServerUser'
+import withAuth from '@/app/api/_utils/withAuth'
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2023-10-16',
 })
 
-export async function POST() {
-  const user = await getServerUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+async function handler(req: any & { user: any }) {
+  const user = req.user
 
   const account = await stripe.accounts.create({
     type: 'express',
@@ -31,3 +30,5 @@ export async function POST() {
 
   return NextResponse.json({ url: link.url })
 }
+
+export const POST = withAuth(handler)


### PR DESCRIPTION
## Summary
- create a server `withAuth` helper for API routes
- use it in bookings, capture-payment, create-checkout-session, disputes, promote-user, reviews, services and stripe connect routes

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414598414883289ea6b46dc34e6814