### PR TITLE
Add cron function to expire stale bookings

### DIFF
--- a/functions/cleanupOldBookings.ts
+++ b/functions/cleanupOldBookings.ts
@@ -1,0 +1,31 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+// Initialize admin SDK if not already initialized
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const DEFAULT_WINDOW_HOURS = 24;
+
+export const cleanupOldBookings = functions.pubsub
+  .schedule('every 60 minutes')
+  .onRun(async () => {
+    const windowHours = parseInt(process.env.BOOKING_EXPIRATION_HOURS || '', 10) || DEFAULT_WINDOW_HOURS;
+    const cutoff = Date.now() - windowHours * 60 * 60 * 1000;
+    const cutoffTs = admin.firestore.Timestamp.fromMillis(cutoff);
+
+    const snapshot = await admin
+      .firestore()
+      .collection('bookings')
+      .where('paid', '==', false)
+      .where('createdAt', '<=', cutoffTs)
+      .get();
+
+    const batch = admin.firestore().batch();
+    snapshot.forEach((doc) => batch.update(doc.ref, { status: 'expired' }));
+    await batch.commit();
+
+    console.log(`Expired ${snapshot.size} old bookings.`);
+    return null;
+  });

--- a/functions/index.js
+++ b/functions/index.js
@@ -13,3 +13,5 @@ exports.grantAdmin = functions.https.onCall(async (data, context) => {
   await admin.auth().setCustomUserClaims(data.uid, { admin: true });
   return { success: true };
 });
+
+exports.cleanupOldBookings = require('./cleanupOldBookings').cleanupOldBookings;


### PR DESCRIPTION
## Summary
- add a Firebase scheduled function `cleanupOldBookings` that expires unpaid bookings
- export the new function from `functions/index.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841598cd8d48328ac017438c20f442c