### PR TITLE
Update firebase-admin peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^16.4.7",
         "firebase": "^11.6.1",
-        "firebase-admin": "^13.4.0",
+        "firebase-admin": "^11.4.1",
         "framer-motion": "^12.5.0",
         "googleapis": "^148.0.0",
         "jose": "^6.0.10",
@@ -3207,9 +3207,8 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.4.0.tgz",
-      "integrity": "sha512-Y8DcyKK+4pl4B93ooiy1G8qvdyRMkcNFfBSh+8rbVcw4cW8dgG0VXCCTp5NUwub8sn9vSPsOwpb9tE2OuFmcfQ==",
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.4.1.tgz",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.4.7",
     "firebase": "^11.6.1",
-    "firebase-admin": "^13.4.0",
+    "firebase-admin": "^11.4.1",
     "framer-motion": "^12.5.0",
     "googleapis": "^148.0.0",
     "jose": "^6.0.10",


### PR DESCRIPTION
## Summary
- downgrade `firebase-admin` to 11.4.x to match adapter requirement

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841693f10708328a3285b5ad1a62cac