### PR TITLE
Add buyer/seller view switch in dashboard

### DIFF
--- a/src/app/(dashboard)/layout/layout.tsx
+++ b/src/app/(dashboard)/layout/layout.tsx
@@ -3,13 +3,19 @@
 import React from 'react';
 import Sidebar from '@/components/dashboard/Sidebar';
 import { useSidebarToggle } from '@/hooks/useSidebarToggle';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuth } from '@/lib/hooks/useAuth';
 
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const { isSidebarOpen, toggleSidebar } = useSidebarToggle();
+  const { open: isSidebarOpen, toggle: toggleSidebar } = useSidebarToggle();
+  const { userData } = useAuth();
+  const isCreator = userData?.role && userData.role !== 'user';
+  const pathname = usePathname();
 
   return (
     <div className="min-h-screen flex bg-black text-white">
@@ -23,7 +29,25 @@ export default function DashboardLayout({
       </div>
 
       {/* Content */}
-      <div className="flex-1 p-4 md:ml-64">{children}</div>
+      <div className="flex-1 p-4 md:ml-64">
+        {isCreator && (
+          <div className="mb-4 flex gap-2">
+            <Link
+              href="/dashboard/bookings"
+              className={`px-3 py-1 rounded text-sm ${pathname.startsWith('/dashboard/bookings') ? 'bg-white text-black' : 'bg-neutral-800 text-white'}`}
+            >
+              I’m Selling
+            </Link>
+            <Link
+              href="/dashboard/purchases"
+              className={`px-3 py-1 rounded text-sm ${pathname.startsWith('/dashboard/purchases') ? 'bg-white text-black' : 'bg-neutral-800 text-white'}`}
+            >
+              I’m Buying
+            </Link>
+          </div>
+        )}
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -2,14 +2,19 @@
 
 import { useSidebarToggle } from '@/hooks/useSidebarToggle';
 import SidebarItem from '@/components/ui/SidebarItem';
+import { useAuth } from '@/lib/hooks/useAuth';
 
-const links = [
-  { href: '/dashboard', label: 'Dashboard Home' },
-  { href: '/dashboard/settings', label: 'Settings' },
-];
+export default function Sidebar({ onClose }: { onClose?: () => void }) {
+  const { open: isOpen, toggle } = useSidebarToggle();
+  const { userData } = useAuth();
+  const isCreator = userData?.role && userData.role !== 'user';
 
-export default function Sidebar() {
-  const { isOpen, toggle } = useSidebarToggle();
+  const links = [
+    { href: '/dashboard', label: 'Dashboard Home' },
+    ...(isCreator ? [{ href: '/dashboard/bookings', label: 'Bookings' }] : []),
+    { href: '/dashboard/purchases', label: 'Purchases' },
+    { href: '/dashboard/settings', label: 'Settings' },
+  ];
 
   return (
     <>
@@ -29,7 +34,9 @@ export default function Sidebar() {
         <nav aria-label="Dashboard navigation">
           <ul className="space-y-2">
             {links.map(({ href, label }) => (
-              <SidebarItem key={href} href={href} label={label} />
+              <li key={href} onClick={onClose}>
+                <SidebarItem href={href} label={label} />
+              </li>
             ))}
           </ul>
         </nav>


### PR DESCRIPTION
## Summary
- extend dashboard sidebar to show Booking/Purchase links
- add toggle in dashboard layout for switching modes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415d3d2bdc8328af404a9182200d14