### PR TITLE
Remove duplicate Navbar usage

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 
 export default function AboutPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
       <div className="max-w-4xl mx-auto px-6 py-20 space-y-10">
         <h1 className="text-4xl font-bold text-center">Our Mission</h1>
 

--- a/src/app/admin/users/[uid]/page.tsx
+++ b/src/app/admin/users/[uid]/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import Navbar from '@/app/components/Navbar';
 
 export default function AdminUserPage() {
   const { uid: rawUid } = useParams();
@@ -31,8 +30,7 @@ export default function AdminUserPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-3xl mx-auto py-12 px-6">
+            <div className="max-w-3xl mx-auto py-12 px-6">
         <h1 className="text-3xl font-bold mb-6">Admin: {user.name || 'Unnamed User'}</h1>
         <p><span className="text-gray-400">UID:</span> {uid}</p>
         <p><span className="text-gray-400">Email:</span> {user.email || 'N/A'}</p>

--- a/src/app/apply/[role]/page.tsx
+++ b/src/app/apply/[role]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import Navbar from '@/app/components/Navbar';
 import { db } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { useAuth } from '@/lib/hooks/useAuth';
@@ -65,8 +64,7 @@ export default function ApplyRolePage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-2xl mx-auto py-12 px-6">
+            <div className="max-w-2xl mx-auto py-12 px-6">
         <OnboardingStepHeader
           step={1}
           total={3}

--- a/src/app/apply/page.tsx
+++ b/src/app/apply/page.tsx
@@ -1,13 +1,11 @@
 'use client';
-import Navbar from '@/app/components/Navbar';
 import RoleSelectCard from '@/components/onboarding/RoleSelectCard';
 import { roles } from '@/utils/roles';
 
 export default function ApplyPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto py-12 px-6">
+            <div className="max-w-4xl mx-auto py-12 px-6">
         <h1 className="text-4xl font-bold mb-4 text-center">Apply to AuditoryX</h1>
         <p className="text-lg text-gray-400 mb-10 text-center">
           Choose your creator role to begin your application.

--- a/src/app/artists/page.jsx
+++ b/src/app/artists/page.jsx
@@ -1,10 +1,8 @@
 'use client';
-import Navbar from '@/app/components/Navbar';
 export default function ArtistsPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Artists</h1>
         <p className="text-gray-400">Explore talented artists worldwide.</p>
       </div>

--- a/src/app/beats/page.js
+++ b/src/app/beats/page.js
@@ -1,11 +1,9 @@
 'use client';
-import Navbar from '@/app/components/Navbar';
 
 export default function BeatsPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Beats Marketplace</h1>
         <p className="text-lg text-gray-400">Discover exclusive beats ready for licensing.</p>
       </div>

--- a/src/app/book/[uid]/page.tsx
+++ b/src/app/book/[uid]/page.tsx
@@ -15,7 +15,6 @@ import {
   serverTimestamp
 } from 'firebase/firestore';
 import { app } from '@/lib/firebase';
-import Navbar from '@/app/components/Navbar';
 import { WeeklyCalendarSelector } from '@/components/booking/WeeklyCalendarSelector';
 import { sendBookingConfirmation } from '@/lib/email/sendBookingConfirmation';
 import { useAuth } from '@/lib/hooks/useAuth';
@@ -120,8 +119,7 @@ export default function BookServicePage({ params }: { params: { uid: string } })
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-6xl mx-auto grid md:grid-cols-3 gap-6 p-6">
+            <div className="max-w-6xl mx-auto grid md:grid-cols-3 gap-6 p-6">
         <div className="md:col-span-2 space-y-4">
           <h1 className="text-3xl font-bold mb-4">Send Booking Request</h1>
           <form onSubmit={handleSubmit} className="flex flex-col space-y-4">

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 
 export default function BookingPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Booking Overview</h1>
         <p className="text-lg text-gray-400">Manage your bookings easily from here.</p>
       </div>

--- a/src/app/cancel/page.tsx
+++ b/src/app/cancel/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 
 export default function CancelPage() {
   return (

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 import Link from 'next/link';
 
 export default function ContactPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-3xl mx-auto px-6 py-16 text-center space-y-8">
+            <div className="max-w-3xl mx-auto px-6 py-16 text-center space-y-8">
         <h1 className="text-4xl font-bold">Contact AuditoryX</h1>
         <p className="text-lg text-gray-400">
           Got a question, partnership idea, or want to join the movement?

--- a/src/app/create-profile/page.tsx
+++ b/src/app/create-profile/page.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import Navbar from '@/app/components/Navbar';
 import CompletionNotice from '@/components/onboarding/CompletionNotice';
 
 export default function CreateProfilePage() {
@@ -47,8 +46,7 @@ export default function CreateProfilePage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <CompletionNotice />
         <h1 className="text-4xl font-bold mb-4">Create Your Profile</h1>
         <p className="text-gray-400">Complete your details and showcase your creative skills to the world.</p>

--- a/src/app/creators/page.jsx
+++ b/src/app/creators/page.jsx
@@ -1,12 +1,10 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 
 export default function CreatorsPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-6">Creators</h1>
         <p className="text-lg text-gray-400 mb-8">Find top creators across all categories.</p>
       </div>

--- a/src/app/dashboard/bookings/[bookingId]/page.tsx
+++ b/src/app/dashboard/bookings/[bookingId]/page.tsx
@@ -4,7 +4,6 @@ import { useParams, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { getDoc, doc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import Navbar from '@/app/components/Navbar';
 import BookingChat from '@/components/chat/BookingChat';
 import ContractViewer from '@/components/contract/ContractViewer';
 import ReleaseFundsButton from '@/components/booking/ReleaseFundsButton';
@@ -50,8 +49,7 @@ export default function BookingDetailPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto py-10 px-6 space-y-8">
+            <div className="max-w-4xl mx-auto py-10 px-6 space-y-8">
         {success && (
           <div className="bg-green-600 text-white text-sm p-3 rounded mb-6">
             ✅ Booking Confirmed — you can now chat with your provider.

--- a/src/app/dashboard/earnings/page.tsx
+++ b/src/app/dashboard/earnings/page.tsx
@@ -12,7 +12,6 @@ import {
   getDoc,
 } from 'firebase/firestore';
 import { app } from '@/lib/firebase';
-import Navbar from '@/app/components/Navbar';
 
 export default function EarningsPage() {
   const [earnings, setEarnings] = useState<any[]>([]);
@@ -72,8 +71,7 @@ export default function EarningsPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto px-6 py-10">
+            <div className="max-w-4xl mx-auto px-6 py-10">
         <h1 className="text-3xl font-bold mb-6">💸 My Earnings</h1>
 
         {earnings.length === 0 ? (

--- a/src/app/dashboard/home/page.tsx
+++ b/src/app/dashboard/home/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 import { useRouter, useSearchParams } from 'next/navigation';
 import clsx from 'clsx';
 import { getAuth, signOut } from 'firebase/auth';
@@ -103,8 +102,7 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto p-6">
+            <div className="max-w-4xl mx-auto p-6">
         {showBanner && (
           <div className="bg-blue-900 border border-blue-500 text-white p-4 rounded-lg mb-6 shadow">
             <div className="flex justify-between items-start">

--- a/src/app/dashboard/orders/page.tsx
+++ b/src/app/dashboard/orders/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 import { useEffect, useState } from 'react';
 import { getAuth } from 'firebase/auth';
 import { getFirestore, collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
@@ -57,8 +56,7 @@ export default function OrdersPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto p-6">
+            <div className="max-w-4xl mx-auto p-6">
         <h1 className="text-3xl font-bold mb-8 text-center">My Orders (Sales)</h1>
         <ul className="space-y-6">
           {orders.map(order => (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 import { useRouter, useSearchParams } from 'next/navigation';
 import clsx from 'clsx';
 import { getAuth, signOut } from 'firebase/auth';
@@ -102,8 +101,7 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex justify-center my-6 gap-4">
+            <div className="flex justify-center my-6 gap-4">
         <Link href="/dashboard/bookings" className={clsx("px-4 py-2 rounded font-medium", { "bg-white text-black": router.pathname === "/dashboard/bookings", "bg-gray-800 text-white": router.pathname !== "/dashboard/bookings" })}>
           I’m Selling
         </Link>

--- a/src/app/dashboard/purchases/[bookingId]/page.tsx
+++ b/src/app/dashboard/purchases/[bookingId]/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { getDoc, doc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import Navbar from '@/app/components/Navbar';
 import BookingChat from '@/components/chat/BookingChat';
 
 export default function PurchaseDetailPage() {
@@ -33,8 +32,7 @@ export default function PurchaseDetailPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto py-10 px-6 space-y-8">
+            <div className="max-w-4xl mx-auto py-10 px-6 space-y-8">
         {success && (
           <div className="bg-green-600 text-white text-sm p-3 rounded mb-6">
             ✅ Booking Confirmed — you can now chat with your provider.

--- a/src/app/dashboard/purchases/page.tsx
+++ b/src/app/dashboard/purchases/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 import { useEffect, useState } from 'react';
 import { getAuth } from 'firebase/auth';
 import { getFirestore, collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
@@ -70,8 +69,7 @@ export default function PurchasesPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto p-6">
+            <div className="max-w-4xl mx-auto p-6">
         <h1 className="text-3xl font-bold mb-8 text-center">My Purchases</h1>
         {success && (
           <div className="bg-green-600 p-4 mb-6 text-white rounded text-center">

--- a/src/app/dashboard/reviews/page.tsx
+++ b/src/app/dashboard/reviews/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 import { useEffect, useState } from 'react';
 import { useAuth } from '@/lib/hooks/useAuth';
 import { db } from '@/lib/firebase';
@@ -56,8 +55,7 @@ export default function ReviewsPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-3xl mx-auto p-6">
+            <div className="max-w-3xl mx-auto p-6">
         <h1 className="text-3xl font-bold mb-6 text-center">My Reviews</h1>
         {reviews.length === 0 ? (
           <p className="text-gray-400 text-center">No reviews yet.</p>

--- a/src/app/dashboard/services/page.tsx
+++ b/src/app/dashboard/services/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import Navbar from '@/app/components/Navbar';
 import Link from 'next/link';
 
 const services = [
@@ -40,8 +39,7 @@ const services = [
 export default function ServicesPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-6xl mx-auto px-6 py-20 space-y-12">
+            <div className="max-w-6xl mx-auto px-6 py-20 space-y-12">
         <div className="text-center">
           <h1 className="text-4xl font-bold mb-3">What You Can Do on AuditoryX</h1>
           <p className="text-gray-400 text-lg max-w-2xl mx-auto">

--- a/src/app/dashboard/upcoming/page.tsx
+++ b/src/app/dashboard/upcoming/page.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react';
 import { getFirestore, collection, query, where, getDocs, orderBy } from 'firebase/firestore';
 import { app } from '@/lib/firebase';
 import { useAuth } from '@/lib/hooks/useAuth';
-import Navbar from '@/app/components/Navbar';
 
 export default function UpcomingBookingsPage() {
   const { user } = useAuth();
@@ -35,8 +34,7 @@ export default function UpcomingBookingsPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto p-6">
+            <div className="max-w-4xl mx-auto p-6">
         <h1 className="text-3xl font-bold mb-6">📅 Upcoming Bookings</h1>
         {bookings.length === 0 ? (
           <p>No upcoming requests.</p>

--- a/src/app/engineers/page.jsx
+++ b/src/app/engineers/page.jsx
@@ -1,10 +1,8 @@
 'use client';
-import Navbar from '@/app/components/Navbar';
 export default function EngineersPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Engineers</h1>
         <p className="text-gray-400">Connect with skilled engineers for your next project.</p>
       </div>

--- a/src/app/explore/[role]/page.tsx
+++ b/src/app/explore/[role]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import Navbar from '@/app/components/Navbar';
 import { getFirestore, collection, getDocs, query, where, doc, updateDoc, getDoc } from 'firebase/firestore';
 import { app } from '@/lib/firebase';
 import { useRouter, useParams } from 'next/navigation';
@@ -73,8 +72,7 @@ export default function ExploreRolePage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-6xl mx-auto p-6">
+            <div className="max-w-6xl mx-auto p-6">
         <h1 className="text-4xl font-bold mb-6 capitalize">{role} Services</h1>
 
         {userData?.isAdmin && (

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { getAuth, signInWithEmailAndPassword, signInWithPopup, GoogleAuthProvider } from 'firebase/auth'
 import { app } from '@/lib/firebase'
-import Navbar from '@/app/components/Navbar'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -38,8 +37,7 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen bg-black text-white p-8 flex flex-col items-center justify-center">
-      <Navbar />
-      <h1 className="text-3xl font-bold mb-6">Log In</h1>
+            <h1 className="text-3xl font-bold mb-6">Log In</h1>
 
       <button
         onClick={handleGoogleLogin}

--- a/src/app/producers/page.jsx
+++ b/src/app/producers/page.jsx
@@ -1,10 +1,8 @@
 'use client';
-import Navbar from '@/app/components/Navbar';
 export default function ProducersPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Producers</h1>
         <p className="text-gray-400">Find top music producers ready to work with you.</p>
       </div>

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 
 export default function SavedPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Saved Listings</h1>
         <p className="text-lg text-gray-400">Your favorite services are saved here.</p>
       </div>

--- a/src/app/services/[id]/page.tsx
+++ b/src/app/services/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import Navbar from '@/app/components/Navbar';
 import { getFirestore, doc, getDoc } from 'firebase/firestore';
 import { app } from '@/lib/firebase';
 import { SaveButton } from '@/components/profile/SaveButton';
@@ -37,8 +36,7 @@ export default function ServiceDetailPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-4xl mx-auto py-12 px-6">
+            <div className="max-w-4xl mx-auto py-12 px-6">
         <h1 className="text-4xl font-bold mb-4">{service.title || 'Untitled Service'}</h1>
         <p className="text-gray-400 mb-6">{service.description || 'No description provided.'}</p>
 

--- a/src/app/services/add/page.tsx
+++ b/src/app/services/add/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import Navbar from '@/app/components/Navbar';
 import { useAuth } from '@/lib/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 
@@ -42,8 +41,7 @@ export default function AddServicePage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-2xl mx-auto py-12 px-6">
+            <div className="max-w-2xl mx-auto py-12 px-6">
         <h1 className="text-3xl font-bold mb-6">Add New Service</h1>
 
         {error && <p className="text-red-400 mb-4">{error}</p>}

--- a/src/app/services/edit/[id]/page.tsx
+++ b/src/app/services/edit/[id]/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { doc, getDoc, updateDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import Navbar from '@/app/components/Navbar';
 
 export default function EditServicePage() {
   const { id: rawId } = useParams();
@@ -59,8 +58,7 @@ export default function EditServicePage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-2xl mx-auto py-12 px-6">
+            <div className="max-w-2xl mx-auto py-12 px-6">
         <h1 className="text-3xl font-bold mb-6">Edit Service</h1>
 
         <div className="space-y-4">

--- a/src/app/studios/page.jsx
+++ b/src/app/studios/page.jsx
@@ -1,10 +1,8 @@
 'use client';
-import Navbar from '@/app/components/Navbar';
 export default function StudiosPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Studios</h1>
         <p className="text-gray-400">Book world-class studios around the globe.</p>
       </div>

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import Navbar from '@/app/components/Navbar';
 import { parseISO, format } from 'date-fns';
 
 export default function BookingSuccessPage() {
@@ -24,8 +23,7 @@ export default function BookingSuccessPage() {
 
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="max-w-xl mx-auto p-8 text-center">
+            <div className="max-w-xl mx-auto p-8 text-center">
         <h1 className="text-4xl font-bold mb-4">✅ Booking Request Sent!</h1>
 
         <p className="text-lg mb-2">

--- a/src/app/test-booking/page.tsx
+++ b/src/app/test-booking/page.tsx
@@ -1,10 +1,8 @@
 'use client';
-import Navbar from '@/app/components/Navbar';
 export default function TestBookingPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Test Booking Page</h1>
         <p className="text-gray-400">This is a test page for booking functionality.</p>
       </div>

--- a/src/app/top-creators/page.tsx
+++ b/src/app/top-creators/page.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import Navbar from '@/app/components/Navbar';
 
 export default function TopCreatorsPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Top Creators</h1>
         <p className="text-lg text-gray-400">Meet the top-rated creators on AuditoryX.</p>
       </div>

--- a/src/app/videographers/page.jsx
+++ b/src/app/videographers/page.jsx
@@ -1,10 +1,8 @@
 'use client';
-import Navbar from '@/app/components/Navbar';
 export default function VideographersPage() {
   return (
     <div className="min-h-screen bg-black text-white">
-      <Navbar />
-      <div className="flex flex-col items-center justify-center text-center p-8">
+            <div className="flex flex-col items-center justify-center text-center p-8">
         <h1 className="text-4xl font-bold mb-4">Videographers</h1>
         <p className="text-gray-400">Capture your vision with expert videographers.</p>
       </div>


### PR DESCRIPTION
## Summary
- drop Navbar import and component from pages
- let layout render the navigation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416f6d28d08328a079a8b9f6245223