### PR TITLE
Use env vars for firebase config

### DIFF
--- a/app_backup_before_migration/firebase.js
+++ b/app_backup_before_migration/firebase.js
@@ -1,13 +1,13 @@
 import { initializeApp } from 'firebase/app';
 
 export const firebaseConfig = {
-  apiKey: "AIzaSyAUHHus8UIz1KPrQMLIc4MSZrDoHzejyPA",
-  authDomain: "auditory-x-open-network.firebaseapp.com",
-  projectId: "auditory-x-open-network",
-  storageBucket: "auditory-x-open-network.firebasestorage.app",
-  messagingSenderId: "827240797874",
-  appId: "1:827240797874:web:28e35367b510a4a34c1bab",
-  measurementId: "G-T4JEJCW28T"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 export const app = initializeApp(firebaseConfig);

--- a/app_backup_before_migration/firebase/index.js
+++ b/app_backup_before_migration/firebase/index.js
@@ -3,13 +3,13 @@ import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyAUHHus8UIz1KPrQMLIc4MSZrDoHzejyPA",
-  authDomain: "auditory-x-open-network.firebaseapp.com",
-  projectId: "auditory-x-open-network",
-  storageBucket: "auditory-x-open-network.appspot.com",
-  messagingSenderId: "827240797874",
-  appId: "1:827240797874:web:28e35367b510a4a34c1bab",
-  measurementId: "G-T4JEJCW28T"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);

--- a/firebase/firebaseConfig.js
+++ b/firebase/firebaseConfig.js
@@ -3,13 +3,13 @@ import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyAUHHus8UIz1KPrQMLIc4MSZrDoHzejyPA",
-  authDomain: "auditory-x-open-network.firebaseapp.com",
-  projectId: "auditory-x-open-network",
-  storageBucket: "auditory-x-open-network.firebasestorage.app",
-  messagingSenderId: "827240797874",
-  appId: "1:827240797874:web:28e35367b510a4a34c1bab",
-  measurementId: "G-T4JEJCW28T"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 const app = initializeApp(firebaseConfig);

--- a/scripts/seedServices.mjs
+++ b/scripts/seedServices.mjs
@@ -2,13 +2,13 @@ import { initializeApp, getApps } from 'firebase/app';
 import { getFirestore, setDoc, doc } from 'firebase/firestore';
 
 const firebaseConfig = {
-  apiKey: "AIzaSyAUHHus8UIz1KPrQMLIc4MSZrDoHzejyPA",
-  authDomain: "auditory-x-open-network.firebaseapp.com",
-  projectId: "auditory-x-open-network",
-  storageBucket: "auditory-x-open-network.appspot.com",
-  messagingSenderId: "827240797874",
-  appId: "1:827240797874:web:28e35367b510a4a34c1bab",
-  measurementId: "G-T4JEJCW28T"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];

--- a/src/app/firebase/index.js
+++ b/src/app/firebase/index.js
@@ -3,13 +3,13 @@ import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyAUHHus8UIz1KPrQMLIc4MSZrDoHzejyPA",
-  authDomain: "auditory-x-open-network.firebaseapp.com",
-  projectId: "auditory-x-open-network",
-  storageBucket: "auditory-x-open-network.appspot.com",
-  messagingSenderId: "827240797874",
-  appId: "1:827240797874:web:28e35367b510a4a34c1bab",
-  measurementId: "G-T4JEJCW28T"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,13 +3,13 @@ import { getFirestore } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 
 const firebaseConfig = {
-  apiKey: "AIzaSyAUHHus8UIz1KPrQMLIc4MSZrDoHzejyPA",
-  authDomain: "auditory-x-open-network.firebaseapp.com",
-  projectId: "auditory-x-open-network",
-  storageBucket: "auditory-x-open-network.firebasestorage.app",
-  messagingSenderId: "827240797874",
-  appId: "1:827240797874:web:28e35367b510a4a34c1bab",
-  measurementId: "G-T4JEJCW28T"
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
 export const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();


### PR DESCRIPTION
## Summary
- load credentials from environment variables in client firebase config files
- replace hardcoded keys with env variables across legacy scripts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416f8db66c8328ae633c286fea5436