### PR TITLE
Implement profile trust signals and review fixes

### DIFF
--- a/src/app/profile/[uid]/page.tsx
+++ b/src/app/profile/[uid]/page.tsx
@@ -7,6 +7,8 @@ import { app } from '@/lib/firebase';
 import { ReviewList } from '@/components/reviews/ReviewList';
 import { PortfolioGrid } from '@/components/profile/PortfolioGrid';
 import { SaveButton } from '@/components/profile/SaveButton';
+import VerifiedBadge from '@/components/ui/VerifiedBadge';
+import TierBadge from '@/components/ui/TierBadge';
 import BookingForm from '@/components/booking/BookingForm';
 import { getAverageRating } from '@/lib/reviews/getAverageRating';
 import { getReviewCount } from '@/lib/reviews/getReviewCount';
@@ -48,13 +50,20 @@ export default function PublicProfilePage() {
 
   return (
     <div className="min-h-screen bg-black text-white flex flex-col items-center justify-center p-6">
-      <h1 className="text-3xl font-bold mb-1">{profile.name || 'Unnamed User'}</h1>
+      <div className="flex items-center mb-1">
+        <h1 className="text-3xl font-bold">{profile.name || 'Unnamed User'}</h1>
+        {(profile.proTier === 'verified' || profile.proTier === 'signature') && <VerifiedBadge />}
+        {profile.proTier === 'signature' && <TierBadge tier="signature" />}
+      </div>
 
+      {profile.proTier === 'verified' && (
+        <p className="text-blue-400 text-sm mb-2" title="Verified by AuditoryX — identity and profile have been reviewed.">Verified Creator</p>
+      )}
       {profile.proTier === 'signature' && (
         <p className="text-purple-400 text-sm mb-2">💎 Signature Creator</p>
       )}
-      {profile.proTier === 'verified' && (
-        <p className="text-blue-400 text-sm mb-2" title="Verified by AuditoryX — identity and profile have been reviewed.">✔ Verified Creator</p>
+      {(!profile.proTier || profile.proTier === 'standard') && (
+        <p className="text-gray-400 text-sm mb-2">Standard Creator</p>
       )}
 
       {profile.averageRating !== undefined && (

--- a/src/components/booking/ReviewForm.tsx
+++ b/src/components/booking/ReviewForm.tsx
@@ -1,10 +1,11 @@
 'use client';
-import { sendInAppNotification } from "@/lib/notifications/sendInAppNotification";
+import { sendInAppNotification } from '@/lib/notifications/sendInAppNotification';
 
 import { useState } from 'react';
 import { submitReview } from '@/lib/firestore/reviews/submitReview';
 import { useAuth } from '@/lib/hooks/useAuth';
 import { toast } from 'sonner';
+import StarRating from '@/components/ui/StarRating';
 
 type ReviewFormProps = {
   bookingId: string;
@@ -33,68 +34,20 @@ export default function ReviewForm({
 
     try {
       await submitReview({
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         bookingId,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         providerId,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
-        clientId: user.uid,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         contractId,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
+        clientId: user.uid,
         text: text.trim(),
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         rating,
+      });
+
       await sendInAppNotification({
         to: providerId,
-        type: "review",
-        title: "New Review Received",
+        type: 'review',
+        title: 'New Review Received',
         message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
-      });
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
+        link: `/dashboard/bookings/${bookingId}`,
       });
 
       setSubmitted(true);
@@ -129,20 +82,7 @@ export default function ReviewForm({
       <div className="text-xs text-right text-gray-500">{text.length}/500</div>
 
       <label htmlFor="review-rating" className="text-sm font-medium">Rating</label>
-      <select
-        id="review-rating"
-        aria-label="Rating out of 5"
-        value={rating}
-        onChange={(e) => setRating(Number(e.target.value))}
-        className="p-2 border rounded"
-        disabled={loading}
-      >
-        {[5, 4, 3, 2, 1].map((n) => (
-          <option key={n} value={n}>
-            {n} Stars
-          </option>
-        ))}
-      </select>
+      <StarRating rating={rating} onChange={setRating} disabled={loading} />
 
       <button
         type="submit"
@@ -159,16 +99,3 @@ export default function ReviewForm({
     </form>
   );
 }
-//   //   console.log('Booking request sent:', message);
-// //   }}
-// //   />
-// //
-// // Example usage
-// // <BookingChatThread bookingId="12345" /> 
-// // <BookingChatThread bookingId="67890" />
-// // <BookingChatThread bookingId="54321" />
-// // <BookingChatThread bookingId="98765" />
-// // <BookingChatThread bookingId="11223" />
-// // <BookingChatThread bookingId="44556" />
-// // <BookingChatThread bookingId="77889" />
-// // <BookingChatThread bookingId="99000" />

--- a/src/components/ui/StarRating.tsx
+++ b/src/components/ui/StarRating.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { AiFillStar } from 'react-icons/ai';
+
+interface StarRatingProps {
+  rating: number;
+  onChange?: (value: number) => void;
+  disabled?: boolean;
+}
+
+export default function StarRating({ rating, onChange, disabled }: StarRatingProps) {
+  return (
+    <div className="flex gap-1" role="radiogroup" aria-label="Rating">
+      {Array.from({ length: 5 }).map((_, i) => {
+        const value = i + 1;
+        return (
+          <button
+            key={value}
+            type="button"
+            aria-label={`${value} star`}
+            onClick={() => !disabled && onChange?.(value)}
+            className="focus:outline-none"
+          >
+            <AiFillStar className={value <= rating ? 'text-yellow-400' : 'text-gray-400'} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/VerifiedBadge.tsx
+++ b/src/components/ui/VerifiedBadge.tsx
@@ -1,0 +1,11 @@
+'use client';
+import { CheckCircle } from 'lucide-react';
+
+export default function VerifiedBadge() {
+  return (
+    <span className="inline-flex items-center text-xs font-semibold text-blue-400 border border-blue-400 rounded-full px-2 py-0.5 ml-2">
+      <CheckCircle className="w-3 h-3 mr-1" />
+      Verified
+    </span>
+  );
+}

--- a/src/lib/firestore/reviews/submitReview.ts
+++ b/src/lib/firestore/reviews/submitReview.ts
@@ -1,4 +1,4 @@
-import { getFirestore, doc, setDoc, collection, serverTimestamp, getDoc } from 'firebase/firestore';
+import { getFirestore, doc, setDoc, collection, serverTimestamp, getDoc, addDoc, updateDoc } from 'firebase/firestore';
 import { app } from '@/lib/firebase';
 
 async function notifyProvider(providerId: string, bookingId: string, rating: number) {
@@ -38,12 +38,13 @@ export async function submitReview(review: Review) {
 
   // Write to contract thread
   const contractReviewRef = doc(db, 'contracts', review.contractId, 'reviews', review.clientId);
-  // Also write to user profile thread
   const userReviewRef = doc(db, 'users', review.providerId, 'reviews', review.clientId);
 
   await Promise.all([
     setDoc(contractReviewRef, reviewData),
-    setDoc(userReviewRef, reviewData)
+    setDoc(userReviewRef, reviewData),
+    addDoc(collection(db, 'reviews'), reviewData),
+    updateDoc(doc(db, 'bookings', review.bookingId), { hasReview: true })
   ]);
 
   await notifyProvider(review.providerId, review.bookingId, review.rating);


### PR DESCRIPTION
## Summary
- add `VerifiedBadge` and `StarRating` UI components
- allow users to rate bookings with stars in `ReviewForm`
- store reviews globally and flag bookings as reviewed
- show verified badge and tier labels on profile page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c3652b288328b2f95471f944621a