### PR TITLE
Add Map-based discovery with clustering

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import DiscoveryGrid from '@/components/explore/DiscoveryGrid';
 import NewExploreGrid from '@/components/explore/NewExploreGrid';
 import FilterPanel from '@/components/explore/FilterPanel';
-import GlobalMapPage from '../map/page';
+import DiscoveryMap from '@/components/explore/DiscoveryMap';
 import { useFeatureFlag } from '@/lib/hooks/useFeatureFlag';
 
 export default function ExplorePage() {
@@ -20,6 +20,8 @@ export default function ExplorePage() {
     service: searchParams.get('service') || '',
     proTier: searchParams.get('proTier') || '',
     searchNearMe: searchParams.get('searchNearMe') === 'true',
+    lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : undefined,
+    lng: searchParams.get('lng') ? parseFloat(searchParams.get('lng')!) : undefined,
   });
 
   useEffect(() => {
@@ -28,7 +30,11 @@ export default function ExplorePage() {
     if (filters.location) query.set('location', filters.location);
     if (filters.service) query.set('service', filters.service);
     if (filters.proTier) query.set('proTier', filters.proTier);
-    if (filters.searchNearMe) query.set('searchNearMe', 'true');
+    if (filters.searchNearMe) {
+      query.set('searchNearMe', 'true');
+      if (filters.lat) query.set('lat', String(filters.lat));
+      if (filters.lng) query.set('lng', String(filters.lng));
+    }
     router.replace('/explore?' + query.toString());
   }, [filters]);
 
@@ -62,7 +68,7 @@ export default function ExplorePage() {
         )
       ) : (
         <div className="h-[80vh] rounded overflow-hidden border border-white">
-          <GlobalMapPage />
+          <DiscoveryMap filters={filters} />
         </div>
       )}
     </div>

--- a/src/components/explore/DiscoveryMap.tsx
+++ b/src/components/explore/DiscoveryMap.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef } from 'react';
+import mapboxgl from 'mapbox-gl';
+import { queryCreators } from '@/lib/firestore/queryCreators';
+import { cityToCoords } from '@/lib/utils/cityToCoords';
+import 'mapbox-gl/dist/mapbox-gl.css';
+
+mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN!;
+
+type Props = {
+  filters: any;
+};
+
+export default function DiscoveryMap({ filters }: Props) {
+  const mapContainer = useRef<HTMLDivElement | null>(null);
+  const map = useRef<mapboxgl.Map | null>(null);
+
+  // initialize map on first render
+  useEffect(() => {
+    if (!map.current) {
+      map.current = new mapboxgl.Map({
+        container: mapContainer.current!,
+        style: 'mapbox://styles/mapbox/dark-v10',
+        center: [139.6917, 35.6895],
+        zoom: 2,
+      });
+    }
+  }, []);
+
+  // load markers when filters change
+  useEffect(() => {
+    if (!map.current) return;
+
+    const load = async () => {
+      const creators = await queryCreators(filters);
+      const features: any[] = [];
+
+      creators.forEach((c: any) => {
+        let lat = c.locationLat;
+        let lng = c.locationLng;
+        if (!lat || !lng) {
+          const key = c.location?.toLowerCase()?.replace(/\s+/g, '') || '';
+          const fb = cityToCoords[key];
+          if (fb) {
+            lng = fb[0];
+            lat = fb[1];
+          }
+        }
+        if (lat && lng) {
+          features.push({
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [lng, lat] },
+            properties: {
+              uid: c.uid,
+              name: c.displayName || 'Unnamed',
+              role: c.role,
+              verified: c.verified || false,
+            },
+          });
+        }
+      });
+
+      const geojson = {
+        type: 'FeatureCollection',
+        features,
+      } as GeoJSON.FeatureCollection;
+
+      if (map.current!.getSource('creators')) {
+        const src = map.current!.getSource('creators') as mapboxgl.GeoJSONSource;
+        src.setData(geojson);
+      } else {
+        map.current!.on('load', () => {
+          if (map.current!.getSource('creators')) return;
+          map.current!.addSource('creators', {
+            type: 'geojson',
+            data: geojson,
+            cluster: true,
+            clusterMaxZoom: 14,
+            clusterRadius: 50,
+          });
+
+          map.current!.addLayer({
+            id: 'clusters',
+            type: 'circle',
+            source: 'creators',
+            filter: ['has', 'point_count'],
+            paint: {
+              'circle-color': '#3B82F6',
+              'circle-radius': [
+                'step',
+                ['get', 'point_count'],
+                15,
+                10,
+                20,
+                30,
+                25,
+              ],
+            },
+          });
+
+          map.current!.addLayer({
+            id: 'cluster-count',
+            type: 'symbol',
+            source: 'creators',
+            filter: ['has', 'point_count'],
+            layout: {
+              'text-field': '{point_count_abbreviated}',
+              'text-size': 12,
+            },
+            paint: {
+              'text-color': '#ffffff',
+            },
+          });
+
+          map.current!.addLayer({
+            id: 'unclustered-point',
+            type: 'circle',
+            source: 'creators',
+            filter: ['!', ['has', 'point_count']],
+            paint: {
+              'circle-color': '#ffffff',
+              'circle-radius': 6,
+              'circle-stroke-width': 1,
+              'circle-stroke-color': '#000000',
+            },
+          });
+
+          map.current!.on('click', 'clusters', (e) => {
+            const features = map
+              .current!
+              .queryRenderedFeatures(e.point, { layers: ['clusters'] });
+            const clusterId = features[0].properties?.cluster_id;
+            const src = map.current!.getSource('creators') as any;
+            src.getClusterExpansionZoom(clusterId, (err: any, zoom: number) => {
+              if (err) return;
+              map.current!.easeTo({
+                center: features[0].geometry.coordinates as [number, number],
+                zoom,
+              });
+            });
+          });
+
+          map.current!.on('click', 'unclustered-point', (e) => {
+            const feature = e.features?.[0];
+            if (!feature) return;
+            const props = feature.properties as any;
+            const html = `<div style="font-size:14px">` +
+              `<strong>${props.name}</strong><br/>` +
+              `${props.role}${props.verified ? ' ✔️' : ''}<br/>` +
+              `<a href="/profile/${props.uid}" target="_blank" class="underline text-blue-400">View Profile</a>` +
+              `</div>`;
+            new mapboxgl.Popup()
+              .setLngLat(feature.geometry.coordinates as any)
+              .setHTML(html)
+              .addTo(map.current!);
+          });
+
+          map.current!.on('mouseenter', 'clusters', () => {
+            map.current!.getCanvas().style.cursor = 'pointer';
+          });
+          map.current!.on('mouseleave', 'clusters', () => {
+            map.current!.getCanvas().style.cursor = '';
+          });
+          map.current!.on('mouseenter', 'unclustered-point', () => {
+            map.current!.getCanvas().style.cursor = 'pointer';
+          });
+          map.current!.on('mouseleave', 'unclustered-point', () => {
+            map.current!.getCanvas().style.cursor = '';
+          });
+        });
+      }
+    };
+
+    load();
+  }, [filters]);
+
+  return <div ref={mapContainer} className="w-full h-full" />;
+}

--- a/src/lib/firestore/queryCreators.ts
+++ b/src/lib/firestore/queryCreators.ts
@@ -1,6 +1,7 @@
 import { isProfileComplete } from '@/lib/profile/isProfileComplete';
 import { db } from '@/lib/firebase';
 import { collection, getDocs, query, where } from 'firebase/firestore';
+import { cityToCoords } from '@/lib/utils/cityToCoords';
 import { UserProfile } from '@/types/user'; // ✅ import type
 
 export async function queryCreators(filters: {
@@ -8,6 +9,9 @@ export async function queryCreators(filters: {
   verifiedOnly?: boolean;
   location?: string;
   proTier?: 'standard' | 'verified' | 'signature';
+  lat?: number;
+  lng?: number;
+  radiusKm?: number;
 }) {
   const qConstraints = [];
 
@@ -30,7 +34,47 @@ export async function queryCreators(filters: {
   const q = query(collection(db, 'users'), ...qConstraints);
   const snapshot = await getDocs(q);
 
-  return snapshot.docs
-    .map((doc) => ({ uid: doc.id, ...doc.data() } as UserProfile)) // ✅ assert type
+  let results = snapshot.docs
+    .map((doc) => ({ uid: doc.id, ...doc.data() } as UserProfile))
     .filter(isProfileComplete);
+
+  if (filters.lat && filters.lng) {
+    const radius = filters.radiusKm ?? 50;
+    const toRad = (v: number) => (v * Math.PI) / 180;
+    const dist = (
+      lat1: number,
+      lng1: number,
+      lat2: number,
+      lng2: number
+    ) => {
+      const R = 6371;
+      const dLat = toRad(lat2 - lat1);
+      const dLng = toRad(lng2 - lng1);
+      const a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(toRad(lat1)) *
+          Math.cos(toRad(lat2)) *
+          Math.sin(dLng / 2) *
+          Math.sin(dLng / 2);
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+      return R * c;
+    };
+
+    results = results.filter((c) => {
+      let lat = (c as any).locationLat as number | null;
+      let lng = (c as any).locationLng as number | null;
+      if (!lat || !lng) {
+        const key = (c as any).location?.toLowerCase()?.replace(/\s+/g, '') || '';
+        const fb = cityToCoords[key];
+        if (fb) {
+          lng = fb[0];
+          lat = fb[1];
+        }
+      }
+      if (!lat || !lng) return false;
+      return dist(lat, lng, filters.lat!, filters.lng!) <= radius;
+    });
+  }
+
+  return results;
 }


### PR DESCRIPTION
## Summary
- enable map view on Explore page
- add Mapbox-powered `DiscoveryMap` with pin clustering
- filter creators by proximity when GPS is enabled

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c39640d48328bf81c53f87d602c0