### PR TITLE
Add keyboard accessible StarRating component

### DIFF
--- a/src/components/ui/StarRating.tsx
+++ b/src/components/ui/StarRating.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { AiFillStar, AiOutlineStar } from 'react-icons/ai'
+import { useState } from 'react'
+
+export type StarRatingProps = {
+  value?: number
+  onChange?: (val: number) => void
+  max?: number
+}
+
+export default function StarRating({ value = 0, onChange, max = 5 }: StarRatingProps) {
+  const [internal, setInternal] = useState(value)
+  const rating = value ?? internal
+
+  const update = (val: number) => {
+    if (onChange) {
+      onChange(val)
+    } else {
+      setInternal(val)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLSpanElement>, index: number) => {
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        e.preventDefault()
+        update(Math.min(max, index + 1))
+        break
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        e.preventDefault()
+        update(Math.max(1, index - 1))
+        break
+      case ' ':
+      case 'Enter':
+        e.preventDefault()
+        update(index)
+        break
+    }
+  }
+
+  return (
+    <div role="radiogroup" className="flex gap-1">
+      {Array.from({ length: max }, (_, i) => i + 1).map((n) => (
+        <span
+          key={n}
+          role="radio"
+          aria-checked={rating >= n}
+          tabIndex={0}
+          onClick={() => update(n)}
+          onKeyDown={(e) => handleKeyDown(e, n)}
+          className="cursor-pointer text-xl"
+        >
+          {rating >= n ? <AiFillStar className="text-yellow-500" /> : <AiOutlineStar />}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/ui/__tests__/StarRating.test.tsx
+++ b/src/components/ui/__tests__/StarRating.test.tsx
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import StarRating from '../StarRating'
+
+describe('StarRating keyboard interactions', () => {
+  test('arrow keys change rating', () => {
+    const div = document.createElement('div')
+    const root = createRoot(div)
+    let rating = 1
+    root.render(<StarRating value={rating} onChange={(r) => (rating = r)} />)
+    const star = div.querySelectorAll('[role="radio"]')[0] as HTMLElement
+    star.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    expect(rating).toBe(2)
+    star.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+    expect(rating).toBe(1)
+  })
+
+  test('space or enter selects rating', () => {
+    const div = document.createElement('div')
+    const root = createRoot(div)
+    let rating = 0
+    root.render(<StarRating value={rating} onChange={(r) => (rating = r)} />)
+    const third = div.querySelectorAll('[role="radio"]')[2] as HTMLElement
+    third.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(rating).toBe(3)
+    third.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }))
+    expect(rating).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary
- add `StarRating` React component with keyboard support and aria attributes
- add unit tests for rating keyboard interactions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c5ab42948328a770dd2435529b56