### PR TITLE
Fix calendar push slots payload

### DIFF
--- a/src/app/components/dashboard/AvailabilityEditor.tsx
+++ b/src/app/components/dashboard/AvailabilityEditor.tsx
@@ -72,7 +72,7 @@ export default function AvailabilityEditor() {
     const res = await fetch('/api/calendar/push', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token }),
+      body: JSON.stringify({ slots: availability }),
     });
 
     if (res.ok) {


### PR DESCRIPTION
## Summary
- send availability slots to the push API when syncing

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d45255f083288e95582e8615918c