### PR TITLE
Link provider availability with profile

### DIFF
--- a/src/app/profile/[uid]/page.tsx
+++ b/src/app/profile/[uid]/page.tsx
@@ -100,7 +100,7 @@ export default function PublicProfilePage() {
 
       <div id="booking-form" className="w-full max-w-xl mt-6">
         <h2 className="text-xl font-semibold mb-2">📩 Send Booking Request</h2>
-        <BookingForm onBook={() => {}} />
+        <BookingForm providerId={uid} onBook={() => {}} />
       </div>
 
       <div className="mt-10 w-full max-w-4xl">

--- a/src/lib/hooks/useAvailability.ts
+++ b/src/lib/hooks/useAvailability.ts
@@ -38,10 +38,19 @@ export function useAvailability() {
     fetch();
   }, [user]);
 
-  const saveAvailability = async (slots: Slot[], notes: string, timezone: string) => {
+  const saveAvailability = async (
+    slots: Slot[],
+    notes: string,
+    timezone: string
+  ) => {
     if (!user) return;
     const ref = doc(db, 'availability', user.uid);
     await setDoc(ref, { slots, notes, timezone }, { merge: true });
+
+    // Also store slots on the user profile for easy reference in bookings
+    const userRef = doc(db, 'users', user.uid);
+    await setDoc(userRef, { availabilitySlots: slots }, { merge: true });
+
     setAvailability(slots);
     setNotes(notes);
     setTimezone(timezone);

--- a/src/lib/hooks/useProviderAvailability.ts
+++ b/src/lib/hooks/useProviderAvailability.ts
@@ -25,7 +25,8 @@ export function useProviderAvailability(uid: string) {
         const userSnap = await getDoc(doc(db, 'users', uid));
         if (userSnap.exists()) {
           const data = userSnap.data();
-          setSlots(data.availability || []);
+          // availabilitySlots is stored directly on the user profile
+          setSlots(data.availabilitySlots || data.availability || []);
           setTimezone(data.timezone || '');
         }
       }


### PR DESCRIPTION
## Summary
- update useAvailability hook to save slot data on user profile
- fallback to `availabilitySlots` when loading provider availability
- pass provider ID to booking form

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d474d704832885a596858a5389da