### PR TITLE
Fix review submission workflow

### DIFF
--- a/src/app/(dashboard)/layout/layout.tsx
+++ b/src/app/(dashboard)/layout/layout.tsx
@@ -7,6 +7,7 @@ import { useSidebarToggle } from '@/hooks/useSidebarToggle';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/lib/hooks/useAuth';
+import ReviewPrompt from '@/components/dashboard/ReviewPrompt';
 
 export default function DashboardLayout({
   children,
@@ -48,6 +49,7 @@ export default function DashboardLayout({
           </div>
         )}
         {children}
+        <ReviewPrompt />
       </div>
       <BottomNav />
     </div>

--- a/src/components/booking/ReviewForm.tsx
+++ b/src/components/booking/ReviewForm.tsx
@@ -1,17 +1,16 @@
 'use client';
-import { sendInAppNotification } from "@/lib/notifications/sendInAppNotification";
 
 import { useState } from 'react';
 import { submitReview } from '@/lib/firestore/reviews/submitReview';
 import { useAuth } from '@/lib/hooks/useAuth';
 import { toast } from 'sonner';
 
-type ReviewFormProps = {
+interface ReviewFormProps {
   bookingId: string;
   providerId: string;
   contractId: string;
   onSubmitSuccess?: () => void;
-};
+}
 
 export default function ReviewForm({
   bookingId,
@@ -30,75 +29,17 @@ export default function ReviewForm({
     if (!user || loading || text.trim().length < 3) return;
 
     setLoading(true);
-
     try {
       await submitReview({
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         bookingId,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         providerId,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         clientId: user.uid,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         contractId,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         text: text.trim(),
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
         rating,
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
       });
-      });
-      await sendInAppNotification({
-        to: providerId,
-        type: "review",
-        title: "New Review Received",
-        message: `You received a ${rating}-star review from a client`,
-        link: `/dashboard/bookings/${bookingId}`
-      });
-
-      setSubmitted(true);
       toast.success('Review submitted!');
+      setSubmitted(true);
       onSubmitSuccess?.();
     } catch (err) {
       console.error(err);
@@ -114,7 +55,9 @@ export default function ReviewForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4 border rounded bg-white text-black">
-      <label htmlFor="review-text" className="text-sm font-medium">Your Review</label>
+      <label htmlFor="review-text" className="text-sm font-medium">
+        Your Review
+      </label>
       <textarea
         id="review-text"
         aria-label="Leave a review"
@@ -128,7 +71,9 @@ export default function ReviewForm({
       />
       <div className="text-xs text-right text-gray-500">{text.length}/500</div>
 
-      <label htmlFor="review-rating" className="text-sm font-medium">Rating</label>
+      <label htmlFor="review-rating" className="text-sm font-medium">
+        Rating
+      </label>
       <select
         id="review-rating"
         aria-label="Rating out of 5"
@@ -149,9 +94,7 @@ export default function ReviewForm({
         aria-label="Submit review"
         disabled={loading || text.trim().length < 3}
         className={`px-4 py-2 rounded text-white font-medium transition ${
-          loading
-            ? 'bg-gray-500 cursor-not-allowed'
-            : 'bg-black hover:bg-white hover:text-black border border-black'
+          loading ? 'bg-gray-500 cursor-not-allowed' : 'bg-black hover:bg-white hover:text-black border border-black'
         }`}
       >
         {loading ? 'Submitting...' : 'Submit Review'}
@@ -159,16 +102,3 @@ export default function ReviewForm({
     </form>
   );
 }
-//   //   console.log('Booking request sent:', message);
-// //   }}
-// //   />
-// //
-// // Example usage
-// // <BookingChatThread bookingId="12345" /> 
-// // <BookingChatThread bookingId="67890" />
-// // <BookingChatThread bookingId="54321" />
-// // <BookingChatThread bookingId="98765" />
-// // <BookingChatThread bookingId="11223" />
-// // <BookingChatThread bookingId="44556" />
-// // <BookingChatThread bookingId="77889" />
-// // <BookingChatThread bookingId="99000" />


### PR DESCRIPTION
## Summary
- clean up `ReviewForm` and use `submitReview`
- update `submitReview` to write global review, mark booking reviewed, and update provider rating
- show `ReviewPrompt` in dashboard layout so completed bookings trigger it

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841d598b9c88328ba9f8d0e0440f8dd