### PR TITLE
Fix user ID checks on service APIs

### DIFF
--- a/src/app/api/artist-services/route.js
+++ b/src/app/api/artist-services/route.js
@@ -13,6 +13,10 @@ export async function POST(req) {
     const decoded = await getAuth(adminApp).verifyIdToken(token);
     const { artistId, service, description } = await req.json();
 
+    if (artistId !== decoded.uid) {
+      return new Response(JSON.stringify({ error: 'Unauthorized artistId' }), { status: 403 });
+    }
+
     if (!artistId || !service || !description) {
       return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
     }

--- a/src/app/api/assign-role/route.ts
+++ b/src/app/api/assign-role/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAuth } from 'firebase-admin/auth';
 import { admin } from '@/lib/firebase-admin';
+import withAuth from '@/app/api/_utils/withAuth';
 
-export async function POST(req: NextRequest) {
+async function handler(req: NextRequest & { user: any }) {
+  if (req.user.role !== 'admin') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
   const { uid, role } = await req.json();
 
   try {
@@ -13,3 +17,5 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Role assignment failed' }, { status: 500 });
   }
 }
+
+export const POST = withAuth(handler);

--- a/src/app/api/engineer-services/route.js
+++ b/src/app/api/engineer-services/route.js
@@ -13,6 +13,10 @@ export async function POST(req) {
     const decoded = await getAuth(adminApp).verifyIdToken(token);
     const { engineerId, services, daws, rate, availability, contact } = await req.json();
 
+    if (engineerId !== decoded.uid) {
+      return new Response(JSON.stringify({ error: 'Unauthorized engineerId' }), { status: 403 });
+    }
+
     if (!engineerId || !services || !daws || !rate || !availability || !contact) {
       return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
     }

--- a/src/app/api/producer-services/route.js
+++ b/src/app/api/producer-services/route.js
@@ -13,6 +13,10 @@ export async function POST(req) {
     const decoded = await getAuth(adminApp).verifyIdToken(token);
     const { producerId, title, bpm, genre, price, link } = await req.json();
 
+    if (producerId !== decoded.uid) {
+      return new Response(JSON.stringify({ error: 'Unauthorized producerId' }), { status: 403 });
+    }
+
     if (!producerId || !title || !bpm || !genre || !price || !link) {
       return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
     }

--- a/src/app/api/profile/availability/route.js
+++ b/src/app/api/profile/availability/route.js
@@ -49,10 +49,19 @@ export async function POST(req) {
 export async function GET(req) {
   try {
     const { searchParams } = new URL(req.url);
+    const authHeader = req.headers.get('authorization');
+    const token = authHeader?.split('Bearer ')[1];
+    if (!token) {
+      return new Response(JSON.stringify({ error: 'Unauthorized: Missing token' }), { status: 401 });
+    }
+    const decoded = await getAuth(adminApp).verifyIdToken(token);
     const uid = searchParams.get('uid');
 
     if (!uid) {
       return new Response(JSON.stringify({ error: 'Missing uid' }), { status: 400 });
+    }
+    if (uid !== decoded.uid) {
+      return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
     }
 
     const docSnap = await getDoc(doc(db, 'userAvailability', uid));

--- a/src/app/api/services/route.js
+++ b/src/app/api/services/route.js
@@ -1,5 +1,5 @@
 import { db } from '@/lib/firebase';
-import { collection, addDoc, updateDoc, deleteDoc, doc, getDocs } from 'firebase/firestore';
+import { collection, addDoc, updateDoc, deleteDoc, doc, getDocs, getDoc } from 'firebase/firestore';
 import { NextResponse } from 'next/server';
 import withAuth from '@/app/api/_utils/withAuth';
 
@@ -37,6 +37,11 @@ async function updateService(req) {
   }
 
   const ref = doc(db, 'services', id);
+  const snap = await getDoc(ref);
+  if (!snap.exists() || snap.data().creatorId !== req.user.uid) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   await updateDoc(ref, { ...updates, updatedAt: Date.now() });
 
   return NextResponse.json({ success: true });
@@ -50,7 +55,13 @@ async function deleteService(req) {
     return NextResponse.json({ error: 'Missing service ID' }, { status: 400 });
   }
 
-  await deleteDoc(doc(db, 'services', id));
+  const ref = doc(db, 'services', id);
+  const snap = await getDoc(ref);
+  if (!snap.exists() || snap.data().creatorId !== req.user.uid) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await deleteDoc(ref);
   return NextResponse.json({ success: true });
 }
 

--- a/src/app/api/set-role/route.ts
+++ b/src/app/api/set-role/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getFirestore, doc, updateDoc } from 'firebase/firestore';
 import { initializeApp, getApps, getApp } from 'firebase/app';
 import { firebaseConfig } from '@/lib/firebase';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/authOptions';
 
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 const db = getFirestore(app);

--- a/src/app/api/studio-availability/route.ts
+++ b/src/app/api/studio-availability/route.ts
@@ -14,6 +14,10 @@ export async function POST(req: NextRequest) {
     const decoded = await getAuth(adminApp).verifyIdToken(token);
     const { timeSlot, studioId } = await req.json();
 
+    if (studioId !== decoded.uid) {
+      return NextResponse.json({ error: 'Unauthorized studioId' }, { status: 403 });
+    }
+
     if (!timeSlot || !studioId) {
       return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
     }

--- a/src/app/api/studio-services/route.js
+++ b/src/app/api/studio-services/route.js
@@ -13,6 +13,10 @@ export async function POST(req) {
     const decoded = await getAuth(adminApp).verifyIdToken(token);
     const { studioId, name, location, amenities, hourlyRate, availability, contact } = await req.json();
 
+    if (studioId !== decoded.uid) {
+      return new Response(JSON.stringify({ error: 'Unauthorized studioId' }), { status: 403 });
+    }
+
     if (!studioId || !name || !location || !amenities || !hourlyRate || !availability || !contact) {
       return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
     }

--- a/src/app/api/videographer-services/route.js
+++ b/src/app/api/videographer-services/route.js
@@ -13,6 +13,10 @@ export async function POST(req) {
     const decoded = await getAuth(adminApp).verifyIdToken(token);
     const { videographerId, location, services, portfolioLink, equipment } = await req.json();
 
+    if (videographerId !== decoded.uid) {
+      return new Response(JSON.stringify({ error: 'Unauthorized videographerId' }), { status: 403 });
+    }
+
     if (!videographerId || !location || !services || !portfolioLink || !equipment) {
       return new Response(JSON.stringify({ error: 'Missing fields' }), { status: 400 });
     }


### PR DESCRIPTION
## Summary
- require admin sessions for role assignments
- verify the requester owns the service when creating listings
- restrict profile availability access to authenticated user
- add ownership checks before updating or deleting services

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d6eebc40832880d3511980dea3df