### PR TITLE
Fix Poppins weight definition

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,11 @@ import { AuthProvider } from '@/context/AuthContext';
 import { Toaster } from 'react-hot-toast';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-body' });
-const poppins = Poppins({ subsets: ['latin'], variable: '--font-heading' });
+const poppins = Poppins({
+  subsets: ['latin'],
+  weight: ['400', '700'],
+  variable: '--font-heading',
+});
 
 export const metadata: Metadata = {
   title: 'AuditoryX Open Network',


### PR DESCRIPTION
## Summary
- specify valid font weights for `Poppins` in the Next.js layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684248e6d0d483288071aaf84ad8b567