### PR TITLE
Fix Tailwind import order

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,10 +1,11 @@
 @import 'mapbox-gl/dist/mapbox-gl.css';
 @import '../styles/tokens.css';
-@import '../styles/components.css';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import '../styles/components.css';
 
 /* Global overrides */
 body {


### PR DESCRIPTION
## Summary
- reorder Tailwind directives in `globals.css` so custom component layers load correctly

## Testing
- `npm test` *(fails: auth/invalid-api-key, missing mongoose)*

------
https://chatgpt.com/codex/tasks/task_e_68424d106b48832898b670c1ab48f549