### PR TITLE
Add Next type definitions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "types": ["node", "next-auth", "jest"],
+    "types": ["node", "next", "next-auth", "jest", "react", "stripe"],
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- include Next, React, and Stripe types in tsconfig

## Testing
- `npm install`
- `npx tsc` *(fails: Cannot find module '@/lib/...')*

------
https://chatgpt.com/codex/tasks/task_e_68424ec90efc8328b494a9845d03873f