### PR TITLE
Fix import path for authOptions

### DIFF
--- a/src/lib/stripe/createSubscriptionSession.ts
+++ b/src/lib/stripe/createSubscriptionSession.ts
@@ -1,6 +1,6 @@
 import { stripe } from '@/lib/stripe';
 import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { authOptions } from '@/lib/authOptions';
 import { getUserProfile } from '@/lib/firestore/getUserProfile';
 
 export async function createSubscriptionSession() {


### PR DESCRIPTION
## Summary
- correct authOptions import path in createSubscriptionSession

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684250977d7483288dcb7cf4393ef262