### PR TITLE
Align Stripe API version with typings

### DIFF
--- a/src/app/api/stripe/connect/route.ts
+++ b/src/app/api/stripe/connect/route.ts
@@ -5,7 +5,7 @@ import { doc, setDoc } from 'firebase/firestore'
 import withAuth from '@/app/api/_utils/withAuth'
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2023-10-16',
+  apiVersion: '2025-02-24.acacia',
 })
 
 async function handler(req: any & { user: any }) {

--- a/src/lib/firestore/bookings/markAsReleased.ts
+++ b/src/lib/firestore/bookings/markAsReleased.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { logActivity } from '@/lib/firestore/logging/logActivity';
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-  apiVersion: '2023-10-16',
+  apiVersion: '2025-02-24.acacia',
 });
 
 const schema = z.object({

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -5,7 +5,7 @@ if (!process.env.STRIPE_SECRET_KEY) {
 }
 
 export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-10-16',
+  apiVersion: '2025-02-24.acacia',
   maxNetworkRetries: 2, // Retry failed requests
   typescript: true,
 });


### PR DESCRIPTION
## Summary
- update Stripe initialization to use `2025-02-24.acacia`
- update other Stripe instances to same API version

## Testing
- `npx tsc` *(fails: Cannot find modules, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68424ed578808328af9aae2cbadbf701