### PR TITLE
Add verificationStatus to user profile type

### DIFF
--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -12,6 +12,11 @@ export interface UserProfile {
     spotify?: string;
   };
   isVerified: boolean;
+  /**
+   * Status of the user's ID verification request. If undefined, no verification
+   * has been submitted yet.
+   */
+  verificationStatus?: 'pending' | 'verified' | 'rejected';
   status: 'approved' | 'rejected';
   createdAt: any;
   timezone: string; // ✅ Required for isProfileComplete


### PR DESCRIPTION
## Summary
- add optional `verificationStatus` field to `UserProfile`

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68425441f2a88328b46a73bc0274c279