### PR TITLE
Use adminDb in getServerUser

### DIFF
--- a/src/lib/getServerUser.ts
+++ b/src/lib/getServerUser.ts
@@ -1,12 +1,12 @@
 import { getAuth } from 'firebase-admin/auth'
-import { admin } from './firebase-admin'
+import { admin, adminDb } from './firebase-admin'
 
 export async function getServerUser(token: string) {
   try {
     const decoded = await getAuth(admin).verifyIdToken(token)
     const uid = decoded.uid
 
-    const snap = await admin.firestore().collection('users').doc(uid).get()
+    const snap = await adminDb.collection('users').doc(uid).get()
     const data = snap.data()
 
     if (data?.banned) return null // 🔒 Block banned users


### PR DESCRIPTION
## Summary
- refactor server user fetch to use `adminDb`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68425452b4708328a98c2d64330bf11c