### PR TITLE
Fix various import issues

### DIFF
--- a/lib/firebaseAdmin.ts
+++ b/lib/firebaseAdmin.ts
@@ -1,0 +1,1 @@
+export { default as adminApp } from '../firebaseAdminServer';

--- a/src/app/api/artist-services/route.js
+++ b/src/app/api/artist-services/route.js
@@ -1,7 +1,7 @@
 import { getFirestore, collection, addDoc, getDocs, serverTimestamp } from 'firebase/firestore';
 import { getAuth } from 'firebase-admin/auth';
 import { app } from '@/lib/firebase';
-import { adminApp } from '@/lib/firebaseAdmin';
+import { adminApp } from '@lib/firebaseAdmin';
 
 export async function POST(req) {
   try {

--- a/src/app/api/availability/route.js
+++ b/src/app/api/availability/route.js
@@ -1,6 +1,6 @@
 import { getFirestore, collection, addDoc, getDocs, query, where, serverTimestamp } from 'firebase/firestore';
 import { getAuth } from 'firebase-admin/auth';
-import { adminApp } from '@/lib/firebaseAdmin';
+import { adminApp } from '@lib/firebaseAdmin';
 import { app } from '@/lib/firebase';
 
 export async function POST(req) {

--- a/src/app/api/engineer-services/route.js
+++ b/src/app/api/engineer-services/route.js
@@ -1,7 +1,7 @@
 import { getFirestore, collection, addDoc, getDocs, serverTimestamp } from 'firebase/firestore';
 import { getAuth } from 'firebase-admin/auth';
 import { app } from '@/lib/firebase';
-import { adminApp } from '@/lib/firebaseAdmin';
+import { adminApp } from '@lib/firebaseAdmin';
 
 export async function POST(req) {
   try {

--- a/src/app/api/producer-services/route.js
+++ b/src/app/api/producer-services/route.js
@@ -1,7 +1,7 @@
 import { getFirestore, collection, addDoc, getDocs, serverTimestamp } from 'firebase/firestore';
 import { getAuth } from 'firebase-admin/auth';
 import { app } from '@/lib/firebase';
-import { adminApp } from '@/lib/firebaseAdmin';
+import { adminApp } from '@lib/firebaseAdmin';
 
 export async function POST(req) {
   try {

--- a/src/app/api/profile/availability/route.js
+++ b/src/app/api/profile/availability/route.js
@@ -1,4 +1,4 @@
-import { adminApp } from '@/lib/firebaseAdmin';
+import { adminApp } from '@lib/firebaseAdmin';
 import { getFirestore, doc, setDoc, getDoc } from 'firebase-admin/firestore';
 import { getAuth } from 'firebase-admin/auth';
 import { z } from 'zod';

--- a/src/app/api/studio-availability/route.ts
+++ b/src/app/api/studio-availability/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getFirestore, collection, addDoc, getDocs, serverTimestamp } from 'firebase/firestore';
 import { getAuth } from 'firebase-admin/auth';
-import { adminApp } from '@/lib/firebaseAdmin';
+import { adminApp } from '@lib/firebaseAdmin';
 import { app } from '@/lib/firebase';
 
 export async function POST(req: NextRequest) {

--- a/src/app/api/studio-services/route.js
+++ b/src/app/api/studio-services/route.js
@@ -1,7 +1,7 @@
 import { getFirestore, collection, addDoc, getDocs, serverTimestamp } from 'firebase/firestore';
 import { getAuth } from 'firebase-admin/auth';
 import { app } from '@/lib/firebase';
-import { adminApp } from '@/lib/firebaseAdmin';
+import { adminApp } from '@lib/firebaseAdmin';
 
 export async function POST(req) {
   try {

--- a/src/app/api/videographer-services/route.js
+++ b/src/app/api/videographer-services/route.js
@@ -1,7 +1,7 @@
 import { getFirestore, collection, addDoc, getDocs, serverTimestamp } from 'firebase/firestore';
 import { getAuth } from 'firebase-admin/auth';
 import { app } from '@/lib/firebase';
-import { adminApp } from '@/lib/firebaseAdmin';
+import { adminApp } from '@lib/firebaseAdmin';
 
 export async function POST(req) {
   try {

--- a/src/app/availability/page.js
+++ b/src/app/availability/page.js
@@ -1,57 +1,5 @@
-<<<<<<< HEAD
-'use client';
-import { useEffect, useState } from 'react';
-import { getFirestore, collection, getDocs } from 'firebase/firestore';
-import { app } from '@/lib/firebase';
-
-export default function AvailabilityViewer() {
-  const [data, setData] = useState([]);
-  const [grouped, setGrouped] = useState({});
-
-  useEffect(() => {
-    const db = getFirestore(app);
-    const fetchData = async () => {
-      const snapshot = await getDocs(collection(db, 'availability'));
-      const docs = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-      setData(docs);
-
-      const groupedByRole = docs.reduce((acc, item) => {
-        if (!acc[item.role]) acc[item.role] = [];
-        acc[item.role].push(item);
-        return acc;
-      }, {});
-      setGrouped(groupedByRole);
-    };
-    fetchData();
-  }, []);
-
-  return (
-    <div style={{ padding: '2rem' }}>
-      <h1>📅 Creator Availability</h1>
-      {Object.entries(grouped).map(([role, entries]) => (
-        <div key={role} style={{ marginTop: '2rem' }}>
-          <h2>{role.charAt(0).toUpperCase() + role.slice(1)}</h2>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
-            {entries.map((entry) => (
-              <div key={entry.id} style={{
-                border: '1px solid #ccc',
-                padding: '1rem',
-                borderRadius: '8px',
-                width: '250px',
-                background: '#f9f9f9'
-              }}>
-                <strong>{entry.name}</strong><br />
-                <small>{entry.email}</small><br />
-                <p><strong>Location:</strong> {entry.location || 'N/A'}</p>
-                <p><strong>Availability:</strong><br />{entry.availability}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-=======
-import AvailabilityForm from "../../components/AvailabilityForm";
+"use client";
+import AvailabilityForm from "../components/AvailabilityForm";
 
 export default function AvailabilityPage() {
   return (
@@ -59,6 +7,5 @@ export default function AvailabilityPage() {
       <h1 className="text-3xl font-bold mb-6">Set Your Availability</h1>
       <AvailabilityForm />
     </main>
->>>>>>> 3126253 (chore: finalize migration prep for rebase)
   );
 }

--- a/src/app/dashboard/bookings/[bookingId]/page.tsx
+++ b/src/app/dashboard/bookings/[bookingId]/page.tsx
@@ -4,7 +4,7 @@ import { useParams, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { getDoc, doc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import BookingChat from '@/components/chat/BookingChat';
+import BookingChat from '@/components/booking/BookingChat';
 import ContractViewer from '@/components/contract/ContractViewer';
 import ReleaseFundsButton from '@/components/booking/ReleaseFundsButton';
 import ReviewForm from '@/components/booking/ReviewForm';

--- a/src/app/dashboard/bookings/page.tsx
+++ b/src/app/dashboard/bookings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import BookingChat from '../../../../components/chat/BookingChat';
+import BookingChat from '@/components/booking/BookingChat';
 import React, { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import ContractViewer from '@/components/contract/ContractViewer';

--- a/src/app/dashboard/purchases/[bookingId]/page.tsx
+++ b/src/app/dashboard/purchases/[bookingId]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { getDoc, doc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
-import BookingChat from '@/components/chat/BookingChat';
+import BookingChat from '@/components/booking/BookingChat';
 
 export default function PurchaseDetailPage() {
   const { bookingId: rawId } = useParams();

--- a/src/app/services/manage/page.js
+++ b/src/app/services/manage/page.js
@@ -1,5 +1,5 @@
 "use client";
-import ServiceManager from "../../../components/ServiceManager";
+import ServiceManager from "../../components/ServiceManager";
 
 export default function ManageServices() {
   return (

--- a/src/app/set-role/page.js
+++ b/src/app/set-role/page.js
@@ -1,60 +1,3 @@
-<<<<<<< HEAD
-'use client';
-
-import { useState } from 'react';
-import { getAuth } from 'firebase/auth';
-import { app } from '@/lib/firebase';
-
-export default function SetRolePage() {
-  const [role, setRole] = useState('');
-  const [status, setStatus] = useState('');
-
-  const handleSetRole = async () => {
-    setStatus('Setting role...');
-    const auth = getAuth(app);
-    const user = auth.currentUser;
-
-    if (!user) {
-      setStatus('Not signed in');
-      return;
-    }
-
-    const token = await user.getIdToken();
-
-    const res = await fetch('/api/set-role', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ role }),
-    });
-
-    const data = await res.json();
-
-    if (data.success) {
-      setStatus('✅ Role set successfully!');
-    } else {
-      setStatus(`❌ ${data.error}`);
-    }
-  };
-
-  return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Set Your Role</h1>
-      <select value={role} onChange={(e) => setRole(e.target.value)}>
-        <option value="">Select a role</option>
-        <option value="artist">Artist</option>
-        <option value="producer">Producer</option>
-        <option value="engineer">Engineer</option>
-        <option value="studio">Studio</option>
-        <option value="videographer">Videographer</option>
-        <option value="designer">Designer</option>
-        <option value="a&r">A&R</option>
-      </select>
-      <button onClick={handleSetRole} style={{ marginLeft: '1rem' }}>Submit</button>
-      <p>{status}</p>
-=======
 "use client";
 import { useEffect, useState } from "react";
 import { auth, db } from "../../firebase/firebaseConfig";
@@ -95,7 +38,6 @@ export default function SetRolePage() {
           </button>
         ))}
       </div>
->>>>>>> 3126253 (chore: finalize migration prep for rebase)
     </div>
   );
 }

--- a/src/components/booking/BookingForm.tsx
+++ b/src/components/booking/BookingForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useAuth } from '@/lib/hooks/useAuth';
 import toast from 'react-hot-toast';
 import WeeklyCalendarSelector from './WeeklyCalendarSelector';
-import { createBooking } from '@/lib/firestore/createBooking';
+import { createBooking } from '@lib/firestore/createBooking';
 import { checkBookingConflict } from '@/lib/firestore/checkBookingConflict';
 import { useProviderAvailability } from '@/lib/hooks/useProviderAvailability';
 import { getNextDateForWeekday } from '@/lib/google/calendar';

--- a/src/components/explore/DiscoveryGrid.tsx
+++ b/src/components/explore/DiscoveryGrid.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { queryCreators } from '@/lib/firestore/queryCreators';
-import { getNextAvailable } from '@/lib/availability/getNextAvailable';
+import { getNextAvailable } from '@/lib/firestore/getNextAvailable';
 import { SaveButton } from '@/components/profile/SaveButton';
 import { getAverageRating } from '@/lib/reviews/getAverageRating';
 import { getReviewCount } from '@/lib/reviews/getReviewCount';

--- a/src/firebase/firebaseConfig.ts
+++ b/src/firebase/firebaseConfig.ts
@@ -1,0 +1,1 @@
+export { app, auth, db, storage } from '../../firebase/firebaseConfig';

--- a/src/lib/stripe/createSubscriptionSession.ts
+++ b/src/lib/stripe/createSubscriptionSession.ts
@@ -1,7 +1,7 @@
 import { stripe } from '@/lib/stripe';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/authOptions';
-import { getUserProfile } from '@/lib/firestore/getUserProfile';
+import { getUserProfile } from '@lib/getUserProfile';
 
 export async function createSubscriptionSession() {
   const session = await getServerSession(authOptions);


### PR DESCRIPTION
## Summary
- resolve merge conflicts in availability and set-role pages
- fix import paths for BookingChat, ServiceManager, getNextAvailable
- adjust API imports to use lib alias
- add re-export for firebaseAdmin and firebaseConfig

## Testing
- `npx jest --runInBand`
- `npm run build` *(fails: Dynamic Code Evaluation and font fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_684256e1a6908328b9cd21f8fad82b64