### PR TITLE
Add Jest tests and config mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ See `.env.example` for a full list of variables required by the project.
 ## Escrow Payments
 
 All payments are placed in escrow when a booking is made. Funds remain held until the work is completed and both parties confirm the outcome. This protects buyers and sellers by ensuring money is only released once the service is delivered.
+
+## Testing
+
+Run the Jest test suite with:
+```bash
+npm test
+```
+
+This will execute all unit tests located in any `__tests__` directories.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.test.ts'],
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1'
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@lib/(.*)$': '<rootDir>/lib/$1'
   }
 };

--- a/lib/firestore/__tests__/createBooking.test.ts
+++ b/lib/firestore/__tests__/createBooking.test.ts
@@ -1,0 +1,40 @@
+import { createBooking } from '../createBooking'
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
+import { firestore } from '@lib/firebase/init'
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  addDoc: jest.fn(),
+  serverTimestamp: jest.fn(() => 'ts'),
+}))
+
+jest.mock('@lib/firebase/init', () => ({
+  firestore: {}
+}))
+
+const mockedCollection = collection as jest.MockedFunction<typeof collection>
+const mockedAddDoc = addDoc as jest.MockedFunction<typeof addDoc>
+
+describe('createBooking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('stores booking data and returns id', async () => {
+    const collRef = {}
+    mockedCollection.mockReturnValue(collRef as any)
+    mockedAddDoc.mockResolvedValue({ id: 'abc123' } as any)
+
+    const booking = { clientId: 'c1', providerId: 'p1', service: 's1', dateTime: 'now', message: 'msg' }
+    const id = await createBooking(booking)
+
+    expect(mockedCollection).toHaveBeenCalledWith(firestore, 'bookings')
+    expect(mockedAddDoc).toHaveBeenCalledWith(collRef, expect.objectContaining({
+      ...booking,
+      status: 'pending',
+      createdAt: 'ts',
+      paid: false,
+    }))
+    expect(id).toBe('abc123')
+  })
+})

--- a/src/lib/utils/__tests__/stripe.test.ts
+++ b/src/lib/utils/__tests__/stripe.test.ts
@@ -1,0 +1,29 @@
+import { loadStripe } from '@stripe/stripe-js'
+
+jest.mock('@stripe/stripe-js', () => ({
+  loadStripe: jest.fn(() => Promise.resolve({})),
+}))
+
+const mockedLoadStripe = loadStripe as jest.MockedFunction<typeof loadStripe>
+
+describe('getStripe helper', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockedLoadStripe.mockClear()
+    delete process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+  })
+
+  it('throws when key is missing', () => {
+    const { getStripe } = require('../stripe')
+    expect(() => getStripe()).toThrow('Missing NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY')
+  })
+
+  it('returns same promise on repeated calls', async () => {
+    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test'
+    const { getStripe } = require('../stripe')
+    const p1 = getStripe()
+    const p2 = getStripe()
+    expect(p1).toBe(p2)
+    await expect(p1).resolves.toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary
- expand Jest moduleNameMapper for `@lib`
- add booking creation tests
- add Stripe helper tests
- document test command in README

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_68426465c6388328904db97348c44e10