### PR TITLE
Fix signup redirect logic

### DIFF
--- a/__tests__/getRedirectAfterSignup.test.ts
+++ b/__tests__/getRedirectAfterSignup.test.ts
@@ -1,0 +1,11 @@
+import { getRedirectAfterSignup } from '@/app/signup/getRedirectAfterSignup';
+
+describe('getRedirectAfterSignup', () => {
+  test('redirects to /apply when role is missing', () => {
+    expect(getRedirectAfterSignup(null, '/dashboard')).toBe('/apply');
+  });
+
+  test('redirects to provided path when role exists', () => {
+    expect(getRedirectAfterSignup('artist', '/dashboard')).toBe('/dashboard');
+  });
+});

--- a/src/app/signup/getRedirectAfterSignup.ts
+++ b/src/app/signup/getRedirectAfterSignup.ts
@@ -1,0 +1,3 @@
+export function getRedirectAfterSignup(role: string | null | undefined, redirectPath: string = '/dashboard') {
+  return role ? redirectPath : '/apply';
+}


### PR DESCRIPTION
## Summary
- add helper to decide where to redirect new users
- redirect to `/apply` when new user has no role
- test the redirect helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684268da2af88328b6c0ece2e87c24d9