### PR TITLE
Fix ProfileCompletionMeter props

### DIFF
--- a/src/app/dashboard/edit/page.tsx
+++ b/src/app/dashboard/edit/page.tsx
@@ -34,7 +34,7 @@ export default function EditDashboard() {
     <div className="p-6 max-w-3xl mx-auto text-white">
       <h1 className="text-xl font-semibold mb-4">Edit Your Profile</h1>
 
-      <ProfileCompletionMeter />
+      <ProfileCompletionMeter profile={profile} />
 
       {/* 🗓️ Editable Availability Grid */}
       <AvailabilitySelector


### PR DESCRIPTION
## Summary
- pass profile object to ProfileCompletionMeter on dashboard edit page

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68426b7888888328908765ebfd23bc8e