### PR TITLE
Add basic translations and use Translate component

### DIFF
--- a/components/ServiceSubmissionForm.js
+++ b/components/ServiceSubmissionForm.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { db } from "../firebase/firebaseConfig";
 import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 import { useSession } from "next-auth/react";
+import { Translate } from "@/i18n/Translate";
 
 export default function ServiceSubmissionForm() {
   const { data: session } = useSession();
@@ -61,7 +62,9 @@ export default function ServiceSubmissionForm() {
         className="w-full p-3 rounded bg-black border border-gray-700 text-white"
         required
       />
-      <button type="submit" className="btn btn-primary w-full">Submit Service</button>
+      <button type="submit" className="btn btn-primary w-full">
+        <Translate t="button.submitService" />
+      </button>
       {status && <p className="text-sm text-blue-400 mt-2">{status}</p>}
     </form>
   );

--- a/src/app/(dashboard)/layout/layout.tsx
+++ b/src/app/(dashboard)/layout/layout.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/lib/hooks/useAuth';
 import ReviewPrompt from '@/components/dashboard/ReviewPrompt';
+import { Translate } from '@/i18n/Translate';
 
 export default function DashboardLayout({
   children,
@@ -38,13 +39,13 @@ export default function DashboardLayout({
               href="/dashboard/bookings"
               className={`px-3 py-1 rounded text-sm ${pathname.startsWith('/dashboard/bookings') ? 'bg-white text-black' : 'bg-neutral-800 text-white'}`}
             >
-              I’m Selling
+              <Translate t="dashboard.selling" />
             </Link>
             <Link
               href="/dashboard/purchases"
               className={`px-3 py-1 rounded text-sm ${pathname.startsWith('/dashboard/purchases') ? 'bg-white text-black' : 'bg-neutral-800 text-white'}`}
             >
-              I’m Buying
+              <Translate t="dashboard.buying" />
             </Link>
           </div>
         )}

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/lib/hooks/useAuth';
 import { getAuth, signOut } from 'firebase/auth';
 import { app } from '@/lib/firebase';
 import { useRouter } from 'next/navigation';
+import { Translate } from '@/i18n/Translate';
 
 export default function Navbar() {
   const { user } = useAuth();
@@ -32,26 +33,32 @@ export default function Navbar() {
       </Link>
 
       <div className="space-x-6 text-sm flex items-center">
-        <Link href="/explore" className="hover:underline">Explore</Link>
+        <Link href="/explore" className="hover:underline">
+          <Translate t="nav.explore" />
+        </Link>
         {!user && (
           <>
-            <Link href="/apply" className="hover:underline">Apply</Link>
+            <Link href="/apply" className="hover:underline">
+              <Translate t="nav.apply" />
+            </Link>
             <button
               onClick={() => router.push('/login')}
               className="hover:underline font-semibold text-blue-400"
             >
-              Login
+              <Translate t="nav.login" />
             </button>
           </>
         )}
         {user && (
           <>
-            <Link href="/dashboard" className="hover:underline">Dashboard</Link>
+            <Link href="/dashboard" className="hover:underline">
+              <Translate t="nav.dashboard" />
+            </Link>
             <button
               onClick={handleLogout}
               className="hover:underline text-red-400"
             >
-              Logout
+              <Translate t="nav.logout" />
             </button>
           </>
         )}

--- a/src/app/services/add/page.tsx
+++ b/src/app/services/add/page.tsx
@@ -5,6 +5,7 @@ import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/lib/hooks/useAuth';
 import { useRouter } from 'next/navigation';
+import { Translate } from '@/i18n/Translate';
 
 export default function AddServicePage() {
   const { user, userData } = useAuth();
@@ -79,7 +80,7 @@ export default function AddServicePage() {
             onClick={handleSubmit}
             className="bg-white text-black font-semibold px-6 py-2 rounded hover:bg-gray-200 transition"
           >
-            Submit Service
+            <Translate t="button.submitService" />
           </button>
         </div>
       </div>

--- a/src/app/services/edit/[id]/page.tsx
+++ b/src/app/services/edit/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { doc, getDoc, updateDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
+import { Translate } from '@/i18n/Translate';
 
 export default function EditServicePage() {
   const { id: rawId } = useParams();
@@ -93,7 +94,7 @@ export default function EditServicePage() {
             onClick={handleSave}
             className="bg-white text-black font-semibold px-6 py-2 rounded hover:bg-gray-200 transition"
           >
-            Save Changes
+            <Translate t="button.saveChanges" />
           </button>
 
           {success && <p className="text-green-400 mt-2">✅ Service updated!</p>}

--- a/src/components/dashboard/BottomNav.tsx
+++ b/src/components/dashboard/BottomNav.tsx
@@ -2,12 +2,13 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { Translate } from '@/i18n/Translate';
 
 const links = [
-  { href: '/dashboard/home', label: 'Home' },
-  { href: '/dashboard/messages', label: 'Messages' },
-  { href: '/dashboard/bookings', label: 'Bookings' },
-  { href: '/dashboard/profile', label: 'Profile' },
+  { href: '/dashboard/home', label: <Translate t="bottomnav.home" /> },
+  { href: '/dashboard/messages', label: <Translate t="bottomnav.messages" /> },
+  { href: '/dashboard/bookings', label: <Translate t="bottomnav.bookings" /> },
+  { href: '/dashboard/profile', label: <Translate t="bottomnav.profile" /> },
 ];
 
 export default function BottomNav() {

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { useSidebarToggle } from '@/hooks/useSidebarToggle';
 import SidebarItem from '@/components/ui/SidebarItem';
 import { useAuth } from '@/lib/hooks/useAuth';
+import { Translate } from '@/i18n/Translate';
 
 export default function Sidebar({ onClose }: { onClose?: () => void }) {
   const { open: isOpen, toggle } = useSidebarToggle();
@@ -10,13 +11,13 @@ export default function Sidebar({ onClose }: { onClose?: () => void }) {
   const isCreator = userData?.role && userData.role !== 'user';
 
   const links = [
-    { href: '/dashboard/home', label: 'Dashboard Home' },
-    { href: '/dashboard/bookings', label: 'Bookings' },
-    { href: '/dashboard/messages', label: 'Messages' },
-    { href: '/dashboard/availability', label: 'Availability' },
-    { href: '/dashboard/earnings', label: 'Finances' },
-    { href: '/dashboard/profile', label: 'Profile' },
-    { href: '/dashboard/settings', label: 'Settings' },
+    { href: '/dashboard/home', label: <Translate t="sidebar.dashboardHome" /> },
+    { href: '/dashboard/bookings', label: <Translate t="sidebar.bookings" /> },
+    { href: '/dashboard/messages', label: <Translate t="sidebar.messages" /> },
+    { href: '/dashboard/availability', label: <Translate t="sidebar.availability" /> },
+    { href: '/dashboard/earnings', label: <Translate t="sidebar.finances" /> },
+    { href: '/dashboard/profile', label: <Translate t="sidebar.profile" /> },
+    { href: '/dashboard/settings', label: <Translate t="sidebar.settings" /> },
   ];
 
   return (

--- a/src/components/ui/SidebarItem.tsx
+++ b/src/components/ui/SidebarItem.tsx
@@ -10,7 +10,7 @@ export default function SidebarItem({
   icon,
 }: {
   href: string;
-  label: string;
+  label: React.ReactNode;
   icon?: React.ReactNode;
 }) {
   const pathname = usePathname();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,22 @@
+{
+  "nav.explore": "Explore",
+  "nav.apply": "Apply",
+  "nav.login": "Login",
+  "nav.dashboard": "Dashboard",
+  "nav.logout": "Logout",
+  "dashboard.selling": "I\u2019m Selling",
+  "dashboard.buying": "I\u2019m Buying",
+  "sidebar.dashboardHome": "Dashboard Home",
+  "sidebar.bookings": "Bookings",
+  "sidebar.messages": "Messages",
+  "sidebar.availability": "Availability",
+  "sidebar.finances": "Finances",
+  "sidebar.profile": "Profile",
+  "sidebar.settings": "Settings",
+  "bottomnav.home": "Home",
+  "bottomnav.messages": "Messages",
+  "bottomnav.bookings": "Bookings",
+  "bottomnav.profile": "Profile",
+  "button.saveChanges": "Save Changes",
+  "button.submitService": "Submit Service"
+}

--- a/src/i18n/jp.json
+++ b/src/i18n/jp.json
@@ -1,0 +1,22 @@
+{
+  "nav.explore": "\u63a2\u7d22",
+  "nav.apply": "\u5bfe\u5fdc",
+  "nav.login": "\u30ed\u30b0\u30a4\u30f3",
+  "nav.dashboard": "\u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9",
+  "nav.logout": "\u30ed\u30b0\u30a2\u30a6\u30c8",
+  "dashboard.selling": "\u8ca9\u58f2\u4e2d",
+  "dashboard.buying": "\u8cfc\u5165\u4e2d",
+  "sidebar.dashboardHome": "\u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9\u30db\u30fc\u30e0",
+  "sidebar.bookings": "\u4e88\u7d04",
+  "sidebar.messages": "\u30e1\u30c3\u30bb\u30fc\u30b8",
+  "sidebar.availability": "\u7a7a\u304d\u72b6\u6cc1",
+  "sidebar.finances": "\u8caf\u91d1",
+  "sidebar.profile": "\u30d7\u30ed\u30d5\u30a3\u30fc\u30eb",
+  "sidebar.settings": "\u8a2d\u5b9a",
+  "bottomnav.home": "\u30db\u30fc\u30e0",
+  "bottomnav.messages": "\u30e1\u30c3\u30bb\u30fc\u30b8",
+  "bottomnav.bookings": "\u4e88\u7d04",
+  "bottomnav.profile": "\u30d7\u30ed\u30d5\u30a3\u30fc\u30eb",
+  "button.saveChanges": "\u5909\u66f4\u3092\u4fdd\u5b58",
+  "button.submitService": "\u30b5\u30fc\u30d3\u30b9\u3092\u9001\u4fe1"
+}

--- a/src/i18n/kr.json
+++ b/src/i18n/kr.json
@@ -1,0 +1,22 @@
+{
+  "nav.explore": "\ud0d0\uc0c9",
+  "nav.apply": "\uc2e0\uccad",
+  "nav.login": "\ub85c\uadf8\uc778",
+  "nav.dashboard": "\ub370\uc2dc\ubcf4\ub4dc",
+  "nav.logout": "\ub85c\uadf8\uc544\uc6c3",
+  "dashboard.selling": "\ud314\ub9bd\uc911",
+  "dashboard.buying": "\uad6c\ub9e4\uc911",
+  "sidebar.dashboardHome": "\ub370\uc2dc\ubcf4\ub4dc \ud648",
+  "sidebar.bookings": "\uc608\uc57d",
+  "sidebar.messages": "\uba54\uc2dc\uc9c0",
+  "sidebar.availability": "\uc751\ub2f5\uac00\ub2a5",
+  "sidebar.finances": "\uc7a5\ubaa8",
+  "sidebar.profile": "\ud504\ub85c\ud544",
+  "sidebar.settings": "\uc124\uc815",
+  "bottomnav.home": "\ud648",
+  "bottomnav.messages": "\uba54\uc2dc\uc9c0",
+  "bottomnav.bookings": "\uc608\uc57d",
+  "bottomnav.profile": "\ud504\ub85c\ud544",
+  "button.saveChanges": "\ubcc0\uacbd \uc800\uc7a5",
+  "button.submitService": "\uc11c\ube44\uc2a4 \uc81c\ucd9c"
+}


### PR DESCRIPTION
## Summary
- add English, Japanese and Korean translations
- wire `Translate` into navigation and dashboard UI
- support translation of service submission/editing buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68426b716f1883289329b16f1405f85d