### PR TITLE
Ensure SendGrid env vars set

### DIFF
--- a/__tests__/sendEmailNotification.test.ts
+++ b/__tests__/sendEmailNotification.test.ts
@@ -1,0 +1,61 @@
+jest.mock('@sendgrid/mail', () => ({
+  __esModule: true,
+  default: {
+    setApiKey: jest.fn(),
+    send: jest.fn().mockResolvedValue(undefined),
+  },
+}))
+let sgMail: any
+
+describe('sendEmailNotification env validation', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    sgMail = require('@sendgrid/mail').default
+    process.env = { ...originalEnv }
+    sgMail.setApiKey.mockClear()
+    sgMail.send.mockClear()
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  test('throws when SENDGRID_API_KEY is missing', async () => {
+    delete process.env.SENDGRID_API_KEY
+    process.env.SENDGRID_FROM_EMAIL = 'from@example.com'
+
+    await expect(import('@/lib/notifications/sendEmailNotification'))
+      .rejects.toThrow('SENDGRID_API_KEY is not defined')
+  })
+
+  test('throws when SENDGRID_FROM_EMAIL is missing', async () => {
+    process.env.SENDGRID_API_KEY = 'key'
+    delete process.env.SENDGRID_FROM_EMAIL
+
+    await expect(import('@/lib/notifications/sendEmailNotification'))
+      .rejects.toThrow('SENDGRID_FROM_EMAIL is not defined')
+  })
+
+  test('sends when variables are defined', async () => {
+    process.env.SENDGRID_API_KEY = 'key'
+    process.env.SENDGRID_FROM_EMAIL = 'from@example.com'
+
+    const module = await import('@/lib/notifications/sendEmailNotification')
+    await module.sendEmailNotification({
+      to: 'to@example.com',
+      subject: 'Sub',
+      text: 'hi',
+    })
+
+    expect(sgMail.setApiKey).toHaveBeenCalledWith('key')
+    expect(sgMail.send).toHaveBeenCalledWith({
+      to: 'to@example.com',
+      from: 'from@example.com',
+      subject: 'Sub',
+      text: 'hi',
+      html: '<p>hi</p>',
+    })
+  })
+})

--- a/src/lib/notifications/sendEmailNotification.ts
+++ b/src/lib/notifications/sendEmailNotification.ts
@@ -1,6 +1,21 @@
 import sgMail from '@sendgrid/mail'
 
-sgMail.setApiKey(process.env.SENDGRID_API_KEY as string)
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY
+const SENDGRID_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL
+
+if (!SENDGRID_API_KEY) {
+  const msg = 'SENDGRID_API_KEY is not defined'
+  console.error(msg)
+  throw new Error(msg)
+}
+
+if (!SENDGRID_FROM_EMAIL) {
+  const msg = 'SENDGRID_FROM_EMAIL is not defined'
+  console.error(msg)
+  throw new Error(msg)
+}
+
+sgMail.setApiKey(SENDGRID_API_KEY)
 
 export async function sendEmailNotification({
   to,
@@ -16,7 +31,7 @@ export async function sendEmailNotification({
   try {
     await sgMail.send({
       to,
-      from: process.env.SENDGRID_FROM_EMAIL as string,
+      from: SENDGRID_FROM_EMAIL,
       subject,
       text,
       html: html || `<p>${text}</p>`


### PR DESCRIPTION
## Summary
- validate SendGrid configuration in `sendEmailNotification`
- add tests for missing env vars and successful send

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68426ca23aa8832890ce0c98457188a6