### PR TITLE
Use dynamic imports for heavy UI

### DIFF
--- a/src/app/apply/[role]/page.tsx
+++ b/src/app/apply/[role]/page.tsx
@@ -7,7 +7,13 @@ import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { useAuth } from '@/lib/hooks/useAuth';
 import { cityToCoords } from '@/lib/utils/cityToCoords';
 import OnboardingStepHeader from '@/components/onboarding/OnboardingStepHeader';
-import { WeeklyCalendarSelector } from '@/components/booking/WeeklyCalendarSelector';
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const WeeklyCalendarSelector = dynamic(
+  () => import('@/components/booking/WeeklyCalendarSelector').then(mod => mod.WeeklyCalendarSelector),
+  { ssr: false }
+);
 import { addDays, startOfWeek, format } from 'date-fns';
 
 export default function ApplyRolePage() {
@@ -167,15 +173,17 @@ export default function ApplyRolePage() {
               {step === 4 && (
                 <div>
                   <label className="text-sm mb-1 block">Availability</label>
-                  <WeeklyCalendarSelector
-                    availability={allAvailability}
-                    multiSelect
-                    onSelect={(slots) =>
-                      setAvailabilitySlots(
-                        Array.isArray(slots) ? slots : [slots]
-                      )
-                    }
-                  />
+                  <Suspense fallback={<div className="p-4">Loading calendar...</div>}>
+                    <WeeklyCalendarSelector
+                      availability={allAvailability}
+                      multiSelect
+                      onSelect={(slots) =>
+                        setAvailabilitySlots(
+                          Array.isArray(slots) ? slots : [slots]
+                        )
+                      }
+                    />
+                  </Suspense>
                 </div>
               )}
 

--- a/src/app/book/[uid]/page.tsx
+++ b/src/app/book/[uid]/page.tsx
@@ -15,7 +15,13 @@ import {
   serverTimestamp
 } from 'firebase/firestore';
 import { app } from '@/lib/firebase';
-import { WeeklyCalendarSelector } from '@/components/booking/WeeklyCalendarSelector';
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const WeeklyCalendarSelector = dynamic(
+  () => import('@/components/booking/WeeklyCalendarSelector').then(mod => mod.WeeklyCalendarSelector),
+  { ssr: false }
+);
 import { sendBookingConfirmation } from '@/lib/email/sendBookingConfirmation';
 import { useAuth } from '@/lib/hooks/useAuth';
 import BookingSummarySidebar from '@/components/booking/BookingSummarySidebar';
@@ -130,10 +136,12 @@ export default function BookServicePage({ params }: { params: { uid: string } })
         <div className="md:col-span-2 space-y-4">
           <h1 className="text-3xl font-bold mb-4">Send Booking Request</h1>
           <form onSubmit={handleSubmit} className="flex flex-col space-y-4">
-            <WeeklyCalendarSelector
-              availability={availability}
-              onSelect={(datetime) => setSelectedTime(datetime as string)}
-            />
+            <Suspense fallback={<div className="p-4">Loading calendar...</div>}>
+              <WeeklyCalendarSelector
+                availability={availability}
+                onSelect={(datetime) => setSelectedTime(datetime as string)}
+              />
+            </Suspense>
 
             <textarea
               className="bg-black border border-white p-4 rounded focus:outline-none"

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -5,7 +5,12 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import DiscoveryGrid from '@/components/explore/DiscoveryGrid';
 import NewExploreGrid from '@/components/explore/NewExploreGrid';
 import FilterPanel from '@/components/explore/FilterPanel';
-import DiscoveryMap from '@/components/explore/DiscoveryMap';
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
+
+const DiscoveryMap = dynamic(() => import('@/components/explore/DiscoveryMap'), {
+  ssr: false,
+});
 import { useFeatureFlag } from '@/lib/hooks/useFeatureFlag';
 
 export default function ExplorePage() {
@@ -68,7 +73,9 @@ export default function ExplorePage() {
         )
       ) : (
         <div className="h-[80vh] rounded overflow-hidden border border-white">
-          <DiscoveryMap filters={filters} />
+          <Suspense fallback={<div className="p-4">Loading map...</div>}>
+            <DiscoveryMap filters={filters} />
+          </Suspense>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- code split heavy components with `next/dynamic`
- lazy load map in Explore
- lazy load calendar in booking and apply pages
- dynamically load `mapbox-gl` on global map page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68426ce157408328a1db582bbcfcefbb