### PR TITLE
Remove console usage from API routes

### DIFF
--- a/lib/createBooking.ts
+++ b/lib/createBooking.ts
@@ -1,6 +1,7 @@
 import { getFirestore, collection, addDoc, Timestamp } from "firebase/firestore"
 import { app } from "../firebase/firebaseConfig"
 import { getStripe } from "@/lib/utils/stripe"
+import { logger } from "./logger"
 
 const db = getFirestore(app)
 
@@ -59,7 +60,7 @@ export async function createBooking({
 
     return { success: true, id: bookingId }
   } catch (err) {
-    console.error("Booking error:", err)
+    logger.error("Booking error:", err)
     return { success: false, error: err }
   }
 }

--- a/lib/email/sendBookingConfirmation.ts
+++ b/lib/email/sendBookingConfirmation.ts
@@ -1,4 +1,5 @@
 import { Resend } from 'resend';
+import { logger } from '../logger';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -16,8 +17,8 @@ export const sendBookingConfirmation = async (toEmail: string, bookingId: string
         </div>
       `,
     });
-    console.log('📧 Email sent to', toEmail);
+    logger.info('📧 Email sent to', toEmail);
   } catch (error) {
-    console.error('❌ Email failed:', error);
+    logger.error('❌ Email failed:', error);
   }
 };

--- a/lib/getUserProfile.ts
+++ b/lib/getUserProfile.ts
@@ -1,5 +1,6 @@
 import { getFirestore, doc, getDoc } from "firebase/firestore";
 import { app } from "@/firebase/firebaseConfig";
+import { logger } from "./logger";
 
 const db = getFirestore(app);
 
@@ -9,7 +10,7 @@ export const getUserProfile = async (uid: string) => {
     const userSnap = await getDoc(userRef);
     return userSnap.exists() ? userSnap.data() : null;
   } catch (error) {
-    console.error("Error fetching user profile:", error);
+    logger.error("Error fetching user profile:", error);
     return null;
   }
 };

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,12 @@
+export const logger = {
+  info: (...args: any[]) => {
+    if (process.env.NODE_ENV !== 'test') {
+      console.log(...args);
+    }
+  },
+  error: (...args: any[]) => {
+    if (process.env.NODE_ENV !== 'test') {
+      console.error(...args);
+    }
+  },
+};

--- a/lib/submitApplication.ts
+++ b/lib/submitApplication.ts
@@ -1,5 +1,6 @@
 import { app } from "@/firebase/firebaseConfig";
 import { getFirestore, collection, addDoc, Timestamp } from "firebase/firestore";
+import { logger } from "./logger";
 
 const db = getFirestore(app);
 
@@ -22,10 +23,10 @@ export async function submitApplication({
       role,
       submittedAt: Timestamp.now(),
     });
-    console.log("Document written with ID: ", docRef.id);
+    logger.info("Document written with ID:", docRef.id);
     return { success: true, id: docRef.id };
   } catch (e) {
-    console.error("Error adding document: ", e);
+    logger.error("Error adding document:", e);
     return { success: false, error: e };
   }
 }

--- a/src/app/api/assign-role/route.ts
+++ b/src/app/api/assign-role/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAuth } from 'firebase-admin/auth';
 import { admin } from '@/lib/firebase-admin';
 import withAuth from '@/app/api/_utils/withAuth';
+import { logger } from '@/lib/logger';
 
 async function handler(req: NextRequest & { user: any }) {
   if (req.user.role !== 'admin') {
@@ -13,7 +14,7 @@ async function handler(req: NextRequest & { user: any }) {
     await getAuth(admin).setCustomUserClaims(uid, { role });
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Error setting role:', error);
+    logger.error('Error setting role:', error);
     return NextResponse.json({ error: 'Role assignment failed' }, { status: 500 });
   }
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
 
 export async function POST() {
   try {
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Logout error:', error);
+    logger.error('Logout error:', error);
     return NextResponse.json(
       { error: 'Logout failed' },
       { status: 500 }

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
+import { logger } from '@/lib/logger';
 
 export async function POST(req: NextRequest) {
   try {
@@ -21,7 +22,7 @@ export async function POST(req: NextRequest) {
       }
     });
   } catch (error) {
-    console.error('Registration error:', error);
+    logger.error('Registration error:', error);
     return NextResponse.json(
       { error: 'Registration failed' },
       { status: 400 }

--- a/src/app/api/auth/session/route.js
+++ b/src/app/api/auth/session/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
+import { logger } from '@/lib/logger';
 
 export async function POST(req) {
   try {
@@ -23,7 +24,7 @@ export async function POST(req) {
       }
     });
   } catch (error) {
-    console.error('Session error:', error);
+    logger.error('Session error:', error);
     return NextResponse.json(
       { error: 'Authentication failed' },
       { status: 401 }

--- a/src/app/api/auth/verify/route.js
+++ b/src/app/api/auth/verify/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import jwt from 'jsonwebtoken';
+import { logger } from '@/lib/logger';
 
 export async function GET(req) {
   try {
@@ -23,7 +24,7 @@ export async function GET(req) {
       email: decoded.email
     });
   } catch (error) {
-    console.error('Verification error:', error);
+    logger.error('Verification error:', error);
     return NextResponse.json(
       { error: 'Invalid token' },
       { status: 401 }

--- a/src/app/api/book/route.ts
+++ b/src/app/api/book/route.ts
@@ -12,6 +12,7 @@ import {
 } from 'firebase/firestore';
 import { z } from 'zod';
 import { logActivity } from '@/lib/firestore/logging/logActivity';
+import { logger } from '@/lib/logger';
 
 const BookingSchema = z.object({
   serviceId: z.string().min(1),
@@ -72,7 +73,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ success: true, requestId: docRef.id });
   } catch (err: any) {
-    console.error('❌ Booking request failed:', err.message);
+    logger.error('❌ Booking request failed:', err.message);
     return NextResponse.json(
       { error: 'Failed to create booking request' },
       { status: 500 }

--- a/src/app/api/capture-payment/route.ts
+++ b/src/app/api/capture-payment/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { db } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import withAuth from '@/app/api/_utils/withAuth';
+import { logger } from '@/lib/logger';
 
 async function handler(req: NextRequest & { user: any }) {
   const schema = z.object({
@@ -23,7 +24,7 @@ async function handler(req: NextRequest & { user: any }) {
     await updatePayoutStatus(paymentIntentId);
     return NextResponse.json({ success: true });
   } catch (err: any) {
-    console.error('❌ Capture Payment Error:', err?.message || err);
+    logger.error('❌ Capture Payment Error:', err?.message || err);
     await addDoc(collection(db, 'stripe_logs'), {
       type: 'capture_payment_error',
       error: err?.message || 'Unknown error',

--- a/src/app/api/create-checkout-session/route.ts
+++ b/src/app/api/create-checkout-session/route.ts
@@ -5,6 +5,7 @@ import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { z } from 'zod';
 import { logActivity } from '@/lib/firestore/logging/logActivity';
 import withAuth from '@/app/api/_utils/withAuth';
+import { logger } from '@/lib/logger';
 
 const CheckoutSchema = z.object({
   bookingId: z.string().min(1),
@@ -44,7 +45,7 @@ async function handler(req: NextRequest & { user: any }) {
     return NextResponse.json({ url });
 
   } catch (err: any) {
-    console.error('❌ Stripe session failed:', err?.message || err);
+    logger.error('❌ Stripe session failed:', err?.message || err);
 
     try {
       await addDoc(collection(db, 'stripe_logs'), {
@@ -58,7 +59,7 @@ async function handler(req: NextRequest & { user: any }) {
         createdAt: serverTimestamp(),
       });
     } catch (logErr) {
-      console.error('🔥 Failed to log error to Firestore:', logErr);
+      logger.error('🔥 Failed to log error to Firestore:', logErr);
     }
 
     return NextResponse.json({ error: 'Stripe session failed' }, { status: 500 });

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sendInAppNotification } from '@/lib/notifications/sendInAppNotification'
 import { sendEmailNotification } from '@/lib/notifications/sendEmailNotification'
+import { logger } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
   const { userId, email, type, title, message, link } = await req.json()
@@ -29,7 +30,7 @@ export async function POST(req: NextRequest) {
     ])
     return NextResponse.json({ success: true })
   } catch (err) {
-    console.error('Notification error:', err)
+    logger.error('Notification error:', err)
     return NextResponse.json({ error: 'Failed' }, { status: 500 })
   }
 }

--- a/src/app/api/payments/create-checkout-session/route.ts
+++ b/src/app/api/payments/create-checkout-session/route.ts
@@ -5,6 +5,7 @@ import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { z } from 'zod';
 import { logActivity } from '@/lib/firestore/logging/logActivity';
 import { getServerUser } from '@/lib/auth/getServerUser';
+import { logger } from '@/lib/logger';
 
 const CheckoutSchema = z.object({
   bookingId: z.string().min(1),
@@ -46,7 +47,7 @@ async function handler(req: NextRequest) {
     return NextResponse.json({ url });
 
   } catch (err: any) {
-    console.error('❌ Stripe session failed:', err?.message || err);
+    logger.error('❌ Stripe session failed:', err?.message || err);
 
     try {
       await addDoc(collection(db, 'stripe_logs'), {
@@ -60,7 +61,7 @@ async function handler(req: NextRequest) {
         createdAt: serverTimestamp(),
       });
     } catch (logErr) {
-      console.error('🔥 Failed to log error to Firestore:', logErr);
+      logger.error('🔥 Failed to log error to Firestore:', logErr);
     }
 
     return NextResponse.json({ error: 'Stripe session failed' }, { status: 500 });

--- a/src/app/api/profile/availability/route.js
+++ b/src/app/api/profile/availability/route.js
@@ -2,6 +2,7 @@ import { adminApp } from '@lib/firebaseAdmin';
 import { getFirestore, doc, setDoc, getDoc } from 'firebase-admin/firestore';
 import { getAuth } from 'firebase-admin/auth';
 import { z } from 'zod';
+import { logger } from '@/lib/logger';
 
 const db = getFirestore(adminApp);
 
@@ -41,7 +42,7 @@ export async function POST(req) {
 
     return new Response(JSON.stringify({ success: true }), { status: 200 });
   } catch (err) {
-    console.error('❌ Availability POST failed:', err.message);
+    logger.error('❌ Availability POST failed:', err.message);
     return new Response(JSON.stringify({ error: err.message }), { status: 500 });
   }
 }
@@ -67,7 +68,7 @@ export async function GET(req) {
     const docSnap = await getDoc(doc(db, 'userAvailability', uid));
     return new Response(JSON.stringify(docSnap.exists ? docSnap.data() : {}), { status: 200 });
   } catch (err) {
-    console.error('❌ Availability GET failed:', err.message);
+    logger.error('❌ Availability GET failed:', err.message);
     return new Response(JSON.stringify({ error: err.message }), { status: 500 });
   }
 }

--- a/src/app/api/stripe/subscribe/route.ts
+++ b/src/app/api/stripe/subscribe/route.ts
@@ -1,12 +1,13 @@
 import { createSubscriptionSession } from '@/lib/stripe/createSubscriptionSession';
 import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
 
 export async function GET() {
   try {
     const url = await createSubscriptionSession();
     return NextResponse.json({ url });
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     return NextResponse.json({ error: 'Unable to create subscription session.' }, { status: 500 });
   }
 }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -5,6 +5,7 @@ import { sendBookingConfirmation } from '@/lib/email/sendBookingConfirmation';
 import { logActivity } from '@/lib/firestore/logging/logActivity';
 import { NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { logger } from '@/lib/logger';
 
 export async function POST(req: Request) {
   const buf = await req.arrayBuffer();
@@ -21,7 +22,7 @@ export async function POST(req: Request) {
       process.env.STRIPE_WEBHOOK_SECRET!
     );
   } catch (err) {
-    console.error('❌ Stripe webhook signature verification failed:', err);
+    logger.error('❌ Stripe webhook signature verification failed:', err);
     await firestore.collection("stripe_logs").add({
       type: "webhook_signature_error",
       error: err?.message || "Invalid signature",
@@ -82,10 +83,10 @@ export async function POST(req: Request) {
           bookingId: metadata.bookingId,
         });
 
-        console.log('✅ Booking confirmed:', metadata.bookingId);
+        logger.info('✅ Booking confirmed:', metadata.bookingId);
       }
     } catch (err: any) {
-      console.error('🔥 Failed to handle Stripe event:', err.message);
+      logger.error('🔥 Failed to handle Stripe event:', err.message);
       await firestore.collection('errorLogs').add({
         type: 'webhook_handling_error',
         message: err.message,

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -4,6 +4,7 @@ import { stripe } from '@/lib/stripe';
 import { updateBookingStatus } from '@/lib/firestore/updateBookingStatus';
 import { markAsHeld } from '@/lib/firestore/bookings/markAsHeld';
 import { generateContract } from '@/lib/firestore/contracts/generateContract';
+import { logger } from '@/lib/logger';
 
 const endpointSecret = process.env.STRIPE_WEBHOOK_SECRET!;
 
@@ -15,7 +16,7 @@ export async function POST(req: NextRequest) {
   try {
     event = stripe.webhooks.constructEvent(rawBody, sig!, endpointSecret);
   } catch (err) {
-    console.error('❌ Stripe webhook signature verification failed.', err);
+    logger.error('❌ Stripe webhook signature verification failed.', err);
     return new NextResponse('Webhook Error', { status: 400 });
   }
 
@@ -39,7 +40,7 @@ export async function POST(req: NextRequest) {
         );
       }
 
-      console.log(`✅ Booking ${bookingId} marked paid and funds held.`);
+      logger.info(`✅ Booking ${bookingId} marked paid and funds held.`);
     }
   }
 


### PR DESCRIPTION
## Summary
- add a small logger helper
- refactor API routes and libs to use `logger`
- remove direct `console.log`/`console.error` calls

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426e51a50483288df43da1284a3497