### PR TITLE
Store booking times in UTC

### DIFF
--- a/lib/firestore/createBooking.ts
+++ b/lib/firestore/createBooking.ts
@@ -8,8 +8,10 @@ export const createBooking = async (bookingData: {
   dateTime: string,
   message?: string
 }) => {
+  const isoTime = new Date(bookingData.dateTime).toISOString();
   const docRef = await addDoc(collection(firestore, 'bookings'), {
     ...bookingData,
+    dateTime: isoTime,
     status: 'pending',
     createdAt: serverTimestamp(),
     paid: false,

--- a/src/lib/firestore/checkBookingConflict.ts
+++ b/src/lib/firestore/checkBookingConflict.ts
@@ -2,10 +2,11 @@ import { collection, getDocs, query, where } from 'firebase/firestore';
 import { firestore } from '@lib/firebase/init';
 
 export async function checkBookingConflict(providerId: string, dateTime: string) {
+  const isoTime = new Date(dateTime).toISOString();
   const q = query(
     collection(firestore, 'bookings'),
     where('providerId', '==', providerId),
-    where('dateTime', '==', dateTime)
+    where('dateTime', '==', isoTime)
   );
   const snap = await getDocs(q);
   return !snap.empty;


### PR DESCRIPTION
## Summary
- save selected time from booking page as UTC ISO string
- use ISO time in overlap checks and booking confirmation
- store bookings via createBooking() with timezone-aware timestamp
- update checkBookingConflict() to compare ISO strings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426e86749c832881497bc144b93d88