### PR TITLE
Fix PostCSS imports

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    'postcss-import': {},
     tailwindcss: {},
     autoprefixer: {},
   },


### PR DESCRIPTION
## Summary
- enable `postcss-import` so Tailwind component imports are processed correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842737402748328a9a469e40f38fb7c