### PR TITLE
Remove local date helper

### DIFF
--- a/src/lib/google/calendar.ts
+++ b/src/lib/google/calendar.ts
@@ -1,6 +1,7 @@
 import { google } from 'googleapis';
 import { adminDb } from '@/lib/firebase-admin';
 import { DateTime } from 'luxon';
+import { getNextDateForWeekday } from '@/lib/google/utils';
 
 type Slot = { day: string; time: string };
 
@@ -47,7 +48,7 @@ export async function pushToGoogleCalendar(
   const calendar = google.calendar({ version: 'v3', auth: oAuth2Client });
 
   for (const slot of slots) {
-    const nextDate = getNextDateForWeekday(slot.day as DayOfWeek);
+    const nextDate = getNextDateForWeekday(slot.day);
 
     const start = DateTime.fromISO(`${nextDate}T${slot.time}`, { zone: timezone });
     const end = start.plus({ minutes: 30 });
@@ -64,22 +65,3 @@ export async function pushToGoogleCalendar(
   }
 }
 
-const dayMap = {
-  Sunday: 0,
-  Monday: 1,
-  Tuesday: 2,
-  Wednesday: 3,
-  Thursday: 4,
-  Friday: 5,
-  Saturday: 6,
-} as const;
-
-type DayOfWeek = keyof typeof dayMap;
-
-export function getNextDateForWeekday(weekday: DayOfWeek): string {
-  const today = new Date();
-  const result = new Date();
-  const diff = (dayMap[weekday] + 7 - today.getDay()) % 7;
-  result.setDate(today.getDate() + diff);
-  return result.toISOString().split('T')[0];
-}


### PR DESCRIPTION
## Summary
- remove `getNextDateForWeekday` helper from `calendar.ts`
- import the helper from `utils.ts`
- update call sites accordingly

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842938dc1e883288329ccda232739e4