### PR TITLE
Fix webpack fallback for fs module

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ const nextConfig = {
       util: require.resolve('util/'),
       stream: require.resolve('stream-browserify'),
       path: require.resolve('path-browserify'),
+      fs: false,
     };
     return config;
   },


### PR DESCRIPTION
## Summary
- add `fs: false` to `webpack.resolve.fallback`

## Testing
- `npm test`
- `npm run build` *(fails due to missing `net`, `dns`, `child_process` but no `fs` error)*

------
https://chatgpt.com/codex/tasks/task_e_6842939a14c083289b5d1b6249df1a63