### PR TITLE
Fix build by moving email logic to server API routes

### DIFF
--- a/src/app/api/send-booking-confirmation/route.ts
+++ b/src/app/api/send-booking-confirmation/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendBookingConfirmation } from '@/lib/email/sendBookingConfirmation';
+import { z } from 'zod';
+
+const Schema = z.object({
+  email: z.string().email(),
+  selectedTime: z.string(),
+  message: z.string(),
+  senderName: z.string().optional(),
+  providerTZ: z.string().optional(),
+  clientTZ: z.string().optional()
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const result = Schema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    const { email, selectedTime, message, senderName, providerTZ, clientTZ } = result.data;
+    const res = await sendBookingConfirmation(email, selectedTime, message, senderName, providerTZ, clientTZ);
+    if (res.error) {
+      return NextResponse.json({ error: res.error }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/book/[uid]/page.tsx
+++ b/src/app/book/[uid]/page.tsx
@@ -22,7 +22,6 @@ const WeeklyCalendarSelector = dynamic(
   () => import('@/components/booking/WeeklyCalendarSelector').then(mod => mod.WeeklyCalendarSelector),
   { ssr: false }
 );
-import { sendBookingConfirmation } from '@/lib/email/sendBookingConfirmation';
 import { useAuth } from '@/lib/hooks/useAuth';
 import BookingSummarySidebar from '@/components/booking/BookingSummarySidebar';
 import TrustBadges from '@/components/booking/TrustBadges';
@@ -104,14 +103,18 @@ export default function BookServicePage({ params }: { params: { uid: string } })
       availability: updated
     });
 
-    await sendBookingConfirmation(
-      providerEmail,
-      selectedTime,
-      message,
-      user?.displayName,
-      providerLocation,
-      Intl.DateTimeFormat().resolvedOptions().timeZone
-    );
+    await fetch('/api/send-booking-confirmation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: providerEmail,
+        selectedTime,
+        message,
+        senderName: user?.displayName,
+        providerTZ: providerLocation,
+        clientTZ: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }),
+    });
 
     await fetch('/api/notifications', {
       method: 'POST',

--- a/src/components/disputes/DisputeForm.tsx
+++ b/src/components/disputes/DisputeForm.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { useState } from 'react'
-import { createDispute } from '@/lib/firestore/disputes/createDispute'
 import { useAuth } from '@/lib/hooks/useAuth'
 import { toast } from 'sonner';
 
@@ -21,13 +20,13 @@ export default function DisputeForm({ bookingId, clientId }: Props) {
 
     setLoading(true);
     try {
-      const result = await createDispute({
-        bookingId,
-        fromUser: clientId,
-        reason: trimmed
+      const res = await fetch('/api/disputes/open', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bookingId, reason: trimmed })
       })
 
-      if (!result?.error) {
+      if (res.ok) {
         const adminEmail = process.env.NEXT_PUBLIC_ADMIN_EMAIL || null
 
         await Promise.all([
@@ -59,8 +58,9 @@ export default function DisputeForm({ bookingId, clientId }: Props) {
         ])
       }
 
-      if (result?.error) {
-        toast.error(result.error);
+      if (!res.ok) {
+        const { error } = await res.json();
+        toast.error(error || 'Submission failed');
       } else {
         toast.success('Dispute submitted successfully!');
         setSubmitted(true);


### PR DESCRIPTION
## Summary
- add API route to send booking confirmation emails server-side
- call new API from booking page
- use existing disputes API in DisputeForm

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68429b26e8d48328b453e962015fa8cc