### PR TITLE
Add service filter for Explore queries

### DIFF
--- a/src/lib/firestore/queryCreators.ts
+++ b/src/lib/firestore/queryCreators.ts
@@ -8,6 +8,7 @@ export async function queryCreators(filters: {
   role?: string;
   verifiedOnly?: boolean;
   location?: string;
+  service?: string;
   proTier?: 'standard' | 'verified' | 'signature';
   lat?: number;
   lng?: number;
@@ -25,6 +26,12 @@ export async function queryCreators(filters: {
 
   if (filters.location) {
     qConstraints.push(where('location', '==', filters.location));
+  }
+
+  if (filters.service) {
+    qConstraints.push(
+      where('services', 'array-contains', filters.service.toLowerCase())
+    );
   }
 
   if (filters.proTier) {


### PR DESCRIPTION
## Summary
- extend `queryCreators` to handle a `service` filter
- `FilterPanel` keeps service input in filter state
- pass filters through grid components

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b7c981548328b1aecac3a0d40b87