### PR TITLE
Fix explore view persistence

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -18,7 +18,9 @@ export default function ExplorePage() {
   const router = useRouter();
   const newExplore = useFeatureFlag('newExplore');
 
-  const [view, setView] = useState<'grid' | 'map'>('grid');
+  const [view, setView] = useState<'grid' | 'map'>(
+    searchParams.get('view') === 'map' ? 'map' : 'grid'
+  );
   const [filters, setFilters] = useState({
     role: searchParams.get('role') || '',
     location: searchParams.get('location') || '',
@@ -40,8 +42,9 @@ export default function ExplorePage() {
       if (filters.lat) query.set('lat', String(filters.lat));
       if (filters.lng) query.set('lng', String(filters.lng));
     }
+    query.set('view', view);
     router.replace('/explore?' + query.toString());
-  }, [filters]);
+  }, [filters, view]);
 
   return (
     <div className="min-h-screen bg-black text-white p-6">

--- a/src/components/explore/NewExploreGrid.tsx
+++ b/src/components/explore/NewExploreGrid.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { queryCreators } from '@/lib/firestore/queryCreators';
 import { getAverageRating } from '@/lib/reviews/getAverageRating';
 import { getReviewCount } from '@/lib/reviews/getReviewCount';
@@ -10,6 +11,7 @@ import { getProfileCompletion } from '@/lib/profile/getProfileCompletion';
 export default function NewExploreGrid({ filters }: { filters: any }) {
   const [creators, setCreators] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const router = useRouter();
 
   useEffect(() => {
     const fetch = async () => {
@@ -36,7 +38,11 @@ export default function NewExploreGrid({ filters }: { filters: any }) {
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
       {creators.map((c: any) => (
-        <div key={c.uid} className="border border-white p-4 rounded-xl hover:bg-neutral-900 transition">
+        <div
+          key={c.uid}
+          id={`creator-${c.uid}`}
+          className="border border-white p-4 rounded-xl hover:bg-neutral-900 transition scroll-mt-24"
+        >
           <div className="flex justify-between items-center mb-2">
             <h2 className="font-semibold text-lg">{c.name || 'Unnamed'}</h2>
             <SaveButton providerId={c.uid} />
@@ -49,6 +55,12 @@ export default function NewExploreGrid({ filters }: { filters: any }) {
           )}
           <p className="text-xs text-gray-500 line-clamp-2 mb-2">{c.bio || 'No bio available.'}</p>
           <p className="text-xs text-blue-400">📊 {c.completion}% Profile Complete</p>
+          <button
+            className="btn btn-primary w-full mt-2"
+            onClick={() => router.push(`/profile/${c.uid}`)}
+          >
+            View Profile
+          </button>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- persist view state in query params and restore on load
- add "View Profile" link on new explore cards with scroll margin

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b7e4a4e48328918c23af19ecda40