### PR TITLE
Implement new notification helper

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,33 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { sendInAppNotification } from '@/lib/notifications/sendInAppNotification'
-import { sendEmailNotification } from '@/lib/notifications/sendEmailNotification'
+import { sendInAppAndEmail } from '@/lib/notifications/sendInAppAndEmail'
 import { logger } from '@lib/logger'
 
 export async function POST(req: NextRequest) {
-  const { userId, email, type, title, message, link } = await req.json()
-  if (!userId && !email) {
-    return NextResponse.json({ error: 'No recipient specified' }, { status: 400 })
-  }
   try {
-    await Promise.all([
-      userId
-        ? sendInAppNotification({
-            to: userId,
-            type,
-            title,
-            message,
-            link
-          })
-        : Promise.resolve(),
-      email
-        ? sendEmailNotification({
-            to: email,
-            subject: title,
-            text: `${message}\n${link}`,
-            html: `<p>${message}</p><p><a href="${link}">View</a></p>`
-          })
-        : Promise.resolve()
-    ])
+    const { toUid, type, payload } = await req.json()
+    if (!toUid || !type || !payload) {
+      return NextResponse.json({ error: 'Invalid data' }, { status: 400 })
+    }
+    await sendInAppAndEmail({ toUid, type, payload })
     return NextResponse.json({ success: true })
   } catch (err) {
     logger.error('Notification error:', err)

--- a/src/components/disputes/DisputeForm.tsx
+++ b/src/components/disputes/DisputeForm.tsx
@@ -34,12 +34,21 @@ export default function DisputeForm({ bookingId, clientId }: Props) {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
-              userId: 'admin-notify',
-              email: adminEmail,
+              toUid: 'admin-notify',
               type: 'dispute',
-              title: 'New Dispute Filed',
-              message: `A user submitted a dispute for booking ${bookingId}`,
-              link: `/admin/disputes`
+              payload: {
+                title: 'New Dispute Filed',
+                message: `A user submitted a dispute for booking ${bookingId}`,
+                link: `/admin/disputes`,
+                ...(adminEmail
+                  ? {
+                      email: adminEmail,
+                      subject: 'New Dispute Filed',
+                      template: 'dispute-notification.html',
+                      data: { bookingId, fromUser: user?.uid, reason: trimmed }
+                    }
+                  : {})
+              }
             })
           }),
           user?.email
@@ -47,11 +56,17 @@ export default function DisputeForm({ bookingId, clientId }: Props) {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                  email: user.email,
+                  toUid: user.uid,
                   type: 'dispute',
-                  title: 'Dispute Submitted',
-                  message: `We received your dispute for booking ${bookingId}`,
-                  link: `/dashboard/disputes`
+                  payload: {
+                    title: 'Dispute Submitted',
+                    message: `We received your dispute for booking ${bookingId}`,
+                    link: `/dashboard/disputes`,
+                    email: user.email,
+                    subject: 'Dispute Submitted',
+                    template: 'dispute-opened.html',
+                    data: { disputeId: bookingId }
+                  }
                 })
               })
             : Promise.resolve()

--- a/src/lib/firestore/disputes/createDispute.ts
+++ b/src/lib/firestore/disputes/createDispute.ts
@@ -1,51 +1,57 @@
-import { db } from '@/lib/firebase';
-import { collection, addDoc, doc, getDoc, setDoc, Timestamp } from 'firebase/firestore';
-import { sendDisputeEmail } from '@/lib/email/sendDisputeEmail';
-import { logActivity } from '@/lib/firestore/logging/logActivity';
-import { z } from 'zod';
+import { db } from '@/lib/firebase'
+import { collection, addDoc, doc, getDoc, setDoc, Timestamp } from 'firebase/firestore'
+import { sendDisputeEmail } from '@/lib/email/sendDisputeEmail'
+import { logActivity } from '@/lib/firestore/logging/logActivity'
+import { z } from 'zod'
+import { sendInAppAndEmail } from '@/lib/notifications/sendInAppAndEmail'
 
 async function notifyAdmin(bookingId: string, fromUser: string, reason: string) {
   const email = process.env.NEXT_PUBLIC_ADMIN_EMAIL || null
-  await fetch('/api/notifications', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      userId: 'admin-notify',
-      email,
-      type: 'dispute',
+  await sendInAppAndEmail({
+    toUid: 'admin-notify',
+    type: 'dispute',
+    payload: {
       title: 'New Dispute Filed',
       message: `A dispute was filed for booking ${bookingId}`,
-      link: `/admin/disputes`
-    })
+      link: `/admin/disputes`,
+      ...(email
+        ? {
+            email,
+            subject: 'New Dispute Filed',
+            template: 'dispute-notification.html',
+            data: { bookingId, fromUser, reason }
+          }
+        : {})
+    }
   })
 }
 
 const disputeSchema = z.object({
   bookingId: z.string().min(1),
   fromUser: z.string().min(1),
-  reason: z.string().min(5),
-});
+  reason: z.string().min(5)
+})
 
 export async function createDispute(input: unknown) {
-  const parsed = disputeSchema.safeParse(input);
+  const parsed = disputeSchema.safeParse(input)
   if (!parsed.success) {
-    console.error('Invalid dispute submission:', parsed.error.format());
-    return { error: 'Invalid dispute data' };
+    console.error('Invalid dispute submission:', parsed.error.format())
+    return { error: 'Invalid dispute data' }
   }
 
-  const { bookingId, fromUser, reason } = parsed.data;
+  const { bookingId, fromUser, reason } = parsed.data
 
   // 🧯 Anti-Spam: Limit 1 dispute per 60 seconds per user
-  const cooldownRef = doc(db, 'disputeCooldowns', fromUser);
-  const cooldownSnap = await getDoc(cooldownRef);
+  const cooldownRef = doc(db, 'disputeCooldowns', fromUser)
+  const cooldownSnap = await getDoc(cooldownRef)
 
   if (cooldownSnap.exists()) {
-    const lastSent = cooldownSnap.data().timestamp?.toMillis() || 0;
-    const now = Date.now();
+    const lastSent = cooldownSnap.data().timestamp?.toMillis() || 0
+    const now = Date.now()
 
     if (now - lastSent < 60_000) {
-      console.warn('Dispute submission throttled for user:', fromUser);
-      return { error: 'You must wait before submitting another dispute.' };
+      console.warn('Dispute submission throttled for user:', fromUser)
+      return { error: 'You must wait before submitting another dispute.' }
     }
   }
 
@@ -55,20 +61,20 @@ export async function createDispute(input: unknown) {
       fromUser,
       reason,
       status: 'open',
-      createdAt: Timestamp.now(),
-    });
+      createdAt: Timestamp.now()
+    })
 
     await setDoc(cooldownRef, {
-      timestamp: Timestamp.now(),
-    });
+      timestamp: Timestamp.now()
+    })
 
-    await sendDisputeEmail(bookingId, fromUser, reason);
-    await notifyAdmin(bookingId, fromUser, reason);
-    await logActivity(fromUser, 'dispute_opened', { bookingId, reason });
+    await sendDisputeEmail(bookingId, fromUser, reason)
+    await notifyAdmin(bookingId, fromUser, reason)
+    await logActivity(fromUser, 'dispute_opened', { bookingId, reason })
 
-    return { success: true };
+    return { success: true }
   } catch (err: any) {
-    console.error('Error creating dispute:', err.message);
-    return { error: 'Dispute could not be submitted.' };
+    console.error('Error creating dispute:', err.message)
+    return { error: 'Dispute could not be submitted.' }
   }
 }

--- a/src/lib/notifications/sendInAppAndEmail.ts
+++ b/src/lib/notifications/sendInAppAndEmail.ts
@@ -1,0 +1,37 @@
+import { db } from '@/lib/firebase'
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore'
+import { sendEmail } from '@/lib/email/sendEmail'
+
+export type NotificationPayload = Record<string, any>
+
+export async function sendInAppAndEmail({
+  toUid,
+  type,
+  payload
+}: {
+  toUid: string
+  type: string
+  payload: NotificationPayload
+}) {
+  await addDoc(collection(db, 'notifications', toUid), {
+    type,
+    ...payload,
+    createdAt: serverTimestamp(),
+    seen: false
+  })
+
+  if (
+    payload.email &&
+    process.env.SMTP_EMAIL &&
+    process.env.SMTP_PASS &&
+    payload.subject &&
+    payload.template
+  ) {
+    await sendEmail(
+      payload.email,
+      payload.subject,
+      payload.template,
+      payload.data || {}
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add `sendInAppAndEmail` helper
- update notification API route to use it
- wire DisputeForm and dispute creation to the new helper

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b80308348328af2ee4e2340ddee2