### PR TITLE
Add gamification utilities

### DIFF
--- a/__tests__/gamification.test.ts
+++ b/__tests__/gamification.test.ts
@@ -1,0 +1,69 @@
+import { logXpEvent } from '@/lib/gamification'
+import { collection, addDoc, doc, getDoc, updateDoc, query, where, getDocs, serverTimestamp, Timestamp } from 'firebase/firestore'
+
+jest.mock('@/lib/firebase', () => ({ db: {} }))
+
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  addDoc: jest.fn(),
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  updateDoc: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  getDocs: jest.fn(),
+  serverTimestamp: jest.fn(() => 'ts'),
+  Timestamp: { fromDate: jest.fn(() => ({ fromDate: true })) }
+}))
+
+const mockedCollection = collection as jest.MockedFunction<typeof collection>
+const mockedAddDoc = addDoc as jest.MockedFunction<typeof addDoc>
+const mockedDoc = doc as jest.MockedFunction<typeof doc>
+const mockedGetDoc = getDoc as jest.MockedFunction<typeof getDoc>
+const mockedUpdateDoc = updateDoc as jest.MockedFunction<typeof updateDoc>
+const mockedQuery = query as jest.MockedFunction<typeof query>
+const mockedWhere = where as jest.MockedFunction<typeof where>
+const mockedGetDocs = getDocs as jest.MockedFunction<typeof getDocs>
+const mockedTimestampFromDate = (Timestamp as any).fromDate as jest.Mock
+
+describe('gamification helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedDoc.mockReturnValue('docRef' as any)
+    mockedCollection.mockReturnValue('collRef' as any)
+    mockedQuery.mockReturnValue('queryRef' as any)
+    mockedWhere.mockReturnValue('whereRef' as any)
+    mockedTimestampFromDate.mockReturnValue('startTs')
+    mockedGetDocs.mockResolvedValue({ docs: [] } as any)
+    mockedGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ points: 0, streakCount: 0, lastActivityAt: { toMillis: () => Date.now() } }) } as any)
+  })
+
+  test('accumulates XP up to daily cap', async () => {
+    await logXpEvent('u1', 10, 'test')
+    expect(mockedAddDoc).toHaveBeenCalledWith('collRef', expect.objectContaining({ xp: 10 }))
+    expect(mockedUpdateDoc).toHaveBeenCalledWith('docRef', expect.objectContaining({ points: 10 }))
+  })
+
+  test('enforces daily 100 XP cap', async () => {
+    mockedGetDocs.mockResolvedValue({ docs: [{ data: () => ({ xp: 60 }) }, { data: () => ({ xp: 40 }) }] } as any)
+    mockedGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ points: 100, streakCount: 0 }) } as any)
+    await logXpEvent('u1', 20, 'test')
+    expect(mockedAddDoc).toHaveBeenCalledWith('collRef', expect.objectContaining({ xp: 0 }))
+    expect(mockedUpdateDoc).toHaveBeenCalledWith('docRef', expect.objectContaining({ points: 100 }))
+  })
+
+  test('streak increments and resets correctly', async () => {
+    const now = Date.now()
+    jest.spyOn(Date, 'now').mockReturnValue(now)
+    // within 24h
+    mockedGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ points: 0, streakCount: 3, lastActivityAt: { toMillis: () => now - 2 * 60 * 60 * 1000 } }) } as any)
+    await logXpEvent('u1', 5, 'quick', { quickReply: true })
+    expect(mockedUpdateDoc).toHaveBeenCalledWith('docRef', expect.objectContaining({ streakCount: 4 }))
+
+    // after 24h gap
+    mockedUpdateDoc.mockClear()
+    mockedGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ points: 0, streakCount: 3, lastActivityAt: { toMillis: () => now - 25 * 60 * 60 * 1000 } }) } as any)
+    await logXpEvent('u1', 5, 'quick', { quickReply: true })
+    expect(mockedUpdateDoc).toHaveBeenCalledWith('docRef', expect.objectContaining({ streakCount: 1 }))
+  })
+})

--- a/firestore.rules
+++ b/firestore.rules
@@ -12,6 +12,11 @@ service cloud.firestore {
     match /users/{userId} {
       allow read: if true;
       allow write: if request.auth.uid == userId || request.auth.token.admin == true;
+
+      match /activities/{activityId} {
+        allow create: if request.auth.uid == userId;
+        allow read: if request.auth.uid == userId || request.auth.token.admin == true;
+      }
     }
 
     // Bookings

--- a/src/lib/gamification.ts
+++ b/src/lib/gamification.ts
@@ -1,0 +1,71 @@
+import { db } from '@/lib/firebase'
+import {
+  doc,
+  getDoc,
+  updateDoc,
+  collection,
+  addDoc,
+  serverTimestamp,
+  query,
+  where,
+  getDocs,
+  Timestamp
+} from 'firebase/firestore'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export interface LogOptions {
+  quickReply?: boolean
+}
+
+export async function logXpEvent(
+  uid: string,
+  xp: number,
+  type: string,
+  options: LogOptions = {}
+) {
+  const userRef = doc(db, 'users', uid)
+  const userSnap = await getDoc(userRef)
+  const userData = userSnap.exists() ? (userSnap.data() as any) : {}
+
+  const now = Date.now()
+  const start = new Date(now)
+  start.setHours(0, 0, 0, 0)
+  const activitiesRef = collection(db, 'users', uid, 'activities')
+  const q = query(activitiesRef, where('createdAt', '>=', Timestamp.fromDate(start)))
+  const todaySnap = await getDocs(q)
+  const earnedToday = todaySnap.docs.reduce((sum, d) => sum + (d.data().xp || 0), 0)
+
+  const remaining = Math.max(0, 100 - earnedToday)
+  const awarded = Math.min(xp, remaining)
+
+  await addDoc(activitiesRef, {
+    xp: awarded,
+    type,
+    createdAt: serverTimestamp(),
+  })
+
+  const last = userData.lastActivityAt?.toMillis
+    ? userData.lastActivityAt.toMillis()
+    : userData.lastActivityAt
+      ? new Date(userData.lastActivityAt).getTime()
+      : undefined
+  let streak = userData.streakCount || 0
+  if (options.quickReply) {
+    if (last && now - last < DAY_MS) {
+      streak += 1
+    } else {
+      streak = 1
+    }
+  } else if (!last || now - last >= DAY_MS) {
+    streak = 0
+  }
+
+  await updateDoc(userRef, {
+    points: (userData.points || 0) + awarded,
+    streakCount: streak,
+    lastActivityAt: serverTimestamp(),
+  })
+
+  return awarded
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -35,6 +35,18 @@ export interface User {
   providerId: string;
   role: 'creator' | 'admin' | 'user';
   isVisible?: boolean; // ✅ Optional for isProfileComplete
+  /**
+   * Total XP points accumulated by the user.
+   */
+  points?: number;
+  /**
+   * Current reply streak count.
+   */
+  streakCount?: number;
+  /**
+   * Timestamp of the user's last activity used for streak tracking.
+   */
+  lastActivityAt?: any;
 }
 
 export interface UserWithProfile extends User {


### PR DESCRIPTION
## Summary
- create gamification helper for XP logging and streak tracking
- allow activities subcollection in firestore rules
- extend `User` type with points and streak metadata
- test XP accumulation, daily cap, and streak logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842c2029b2883288d91d8fceba2ec0b