### PR TITLE
Add gamification referral codes

### DIFF
--- a/__tests__/referrals.test.ts
+++ b/__tests__/referrals.test.ts
@@ -1,0 +1,77 @@
+import { generateReferralCode, redeemReferralCode } from '@/lib/referrals'
+import { logXpEvent } from '@/lib/gamification'
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  setDoc,
+  getDoc,
+  updateDoc,
+  serverTimestamp,
+} from 'firebase/firestore'
+
+jest.mock('@/lib/firebase', () => ({ db: {} }))
+jest.mock('@/lib/gamification', () => ({ logXpEvent: jest.fn() }))
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  getDocs: jest.fn(),
+  doc: jest.fn(),
+  setDoc: jest.fn(),
+  getDoc: jest.fn(),
+  updateDoc: jest.fn(),
+  serverTimestamp: jest.fn(() => 'ts'),
+}))
+
+const mockedCollection = collection as jest.MockedFunction<typeof collection>
+const mockedQuery = query as jest.MockedFunction<typeof query>
+const mockedWhere = where as jest.MockedFunction<typeof where>
+const mockedGetDocs = getDocs as jest.MockedFunction<typeof getDocs>
+const mockedDoc = doc as jest.MockedFunction<typeof doc>
+const mockedSetDoc = setDoc as jest.MockedFunction<typeof setDoc>
+const mockedGetDoc = getDoc as jest.MockedFunction<typeof getDoc>
+const mockedUpdateDoc = updateDoc as jest.MockedFunction<typeof updateDoc>
+const mockedLogXp = logXpEvent as jest.MockedFunction<typeof logXpEvent>
+
+describe('referral helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedCollection.mockReturnValue('codes' as any)
+    mockedQuery.mockReturnValue('q' as any)
+    mockedWhere.mockReturnValue('where' as any)
+    mockedDoc.mockReturnValue('docRef' as any)
+  })
+
+  test('generates a new code when none exists', async () => {
+    mockedGetDocs.mockResolvedValue({ empty: true, docs: [] } as any)
+    const code = await generateReferralCode('u1')
+    expect(mockedSetDoc).toHaveBeenCalled()
+    expect(code).toHaveLength(6)
+  })
+
+  test('returns existing code if present', async () => {
+    mockedGetDocs.mockResolvedValue({ empty: false, docs: [{ id: 'ABC123' }] } as any)
+    const code = await generateReferralCode('u1')
+    expect(mockedSetDoc).not.toHaveBeenCalled()
+    expect(code).toBe('ABC123')
+  })
+
+  test('redeems valid code and awards XP', async () => {
+    mockedGetDoc.mockResolvedValueOnce({ exists: () => true, data: () => ({ ownerId: 'u1' }) } as any)
+    mockedGetDoc.mockResolvedValueOnce({ exists: () => true, data: () => ({}) } as any)
+    const ok = await redeemReferralCode('u2', 'CODE')
+    expect(ok).toBe(true)
+    expect(mockedUpdateDoc).toHaveBeenCalledTimes(2)
+    expect(mockedLogXp).toHaveBeenCalledWith('u2', 500, 'referral')
+  })
+
+  test('fails for invalid code', async () => {
+    mockedGetDoc.mockResolvedValue({ exists: () => false } as any)
+    const ok = await redeemReferralCode('u2', 'BAD')
+    expect(ok).toBe(false)
+    expect(mockedLogXp).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/referrals/route.ts
+++ b/src/app/api/referrals/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+import withAuth from '@/app/api/_utils/withAuth'
+import { generateReferralCode, redeemReferralCode } from '@/lib/referrals'
+
+export const GET = withAuth(async (req: NextRequest & { user: any }) => {
+  const code = await generateReferralCode(req.user.uid)
+  return NextResponse.json({ code })
+})
+
+export const POST = withAuth(async (req: NextRequest & { user: any }) => {
+  const { code } = await req.json()
+  if (!code) {
+    return NextResponse.json({ error: 'Missing code' }, { status: 400 })
+  }
+  const success = await redeemReferralCode(req.user.uid, code)
+  if (!success) {
+    return NextResponse.json({ error: 'Invalid code' }, { status: 400 })
+  }
+  return NextResponse.json({ success: true })
+})

--- a/src/lib/referrals.ts
+++ b/src/lib/referrals.ts
@@ -1,0 +1,54 @@
+import { db } from '@/lib/firebase'
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  setDoc,
+  getDoc,
+  updateDoc,
+  serverTimestamp,
+} from 'firebase/firestore'
+import { logXpEvent } from '@/lib/gamification'
+
+const REFERRAL_XP = 500
+
+async function getReferralCode(uid: string): Promise<string | null> {
+  const codesRef = collection(db, 'referralCodes')
+  const q = query(codesRef, where('ownerId', '==', uid))
+  const snap = await getDocs(q)
+  return snap.empty ? null : snap.docs[0].id
+}
+
+export async function generateReferralCode(uid: string): Promise<string> {
+  const existing = await getReferralCode(uid)
+  if (existing) return existing
+
+  const code = Math.random().toString(36).substring(2, 8).toUpperCase()
+  await setDoc(doc(db, 'referralCodes', code), {
+    ownerId: uid,
+    createdAt: serverTimestamp(),
+  })
+  return code
+}
+
+export async function redeemReferralCode(
+  uid: string,
+  code: string,
+): Promise<boolean> {
+  const codeRef = doc(db, 'referralCodes', code)
+  const snap = await getDoc(codeRef)
+  if (!snap.exists()) return false
+  const data = snap.data() as any
+  if (data.ownerId === uid || data.redeemedBy) return false
+
+  const userRef = doc(db, 'users', uid)
+  const userSnap = await getDoc(userRef)
+  if (userSnap.exists() && (userSnap.data() as any).referredBy) return false
+
+  await updateDoc(codeRef, { redeemedBy: uid, redeemedAt: serverTimestamp() })
+  await updateDoc(userRef, { referredBy: data.ownerId })
+  await logXpEvent(uid, REFERRAL_XP, 'referral')
+  return true
+}


### PR DESCRIPTION
## Summary
- add referral code library
- expose API route for generating and redeeming codes
- test referral logic

## Testing
- `npm test`
- `pnpm test gamification`


------
https://chatgpt.com/codex/tasks/task_e_6842d859aec4832893d840cf6d3e19fa