### PR TITLE
Add paginated search with infinite scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/typography": "^0.5.16",
+        "@tanstack/react-query": "^5.29.12",
         "assert": "^2.1.0",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
@@ -5394,6 +5395,32 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.6.tgz",
+      "integrity": "sha512-nl7YxT/TAU+VTf+e2zTkObGTyY8YZBMnbgeA1ee66lIVqzKlYursAII6z5t0e6rXgwUMJSV4dshBTNacNpZHbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.6.tgz",
+      "integrity": "sha512-izX+5CnkpON3NQGcEm3/d7LfFQNo9ZpFtX2QsINgCYK9LT2VCIdi8D3bMaMSNhrAJCznRoAkFic76uvLroALBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "stripe": "^17.7.0",
     "mongoose": "^8.3.1",
     "util": "^0.12.5",
-    "zod": "^3.25.3"
+    "zod": "^3.25.3",
+    "@tanstack/react-query": "^5.29.12"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/providers/QueryProvider.tsx
+++ b/providers/QueryProvider.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode, useState } from 'react'
+
+export default function QueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(() => new QueryClient())
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import { queryCreators } from '@/lib/firestore/queryCreators'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const limit = parseInt(searchParams.get('limit') || '10', 10)
+  const cursor = searchParams.get('cursor') || undefined
+
+  const filters: any = {
+    role: searchParams.get('role') || undefined,
+    location: searchParams.get('location') || undefined,
+    service: searchParams.get('service') || undefined,
+    proTier: searchParams.get('proTier') || undefined,
+    verifiedOnly: searchParams.get('verifiedOnly') === 'true',
+    lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : undefined,
+    lng: searchParams.get('lng') ? parseFloat(searchParams.get('lng')!) : undefined,
+  }
+
+  const { results, nextCursor } = await queryCreators({
+    ...filters,
+    limit,
+    cursor,
+  })
+
+  return NextResponse.json({ results, nextCursor })
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Metadata } from 'next';
 import { LanguageProvider } from '@/context/LanguageContext';
 import { AuthProvider } from '@/context/AuthContext';
 import { Toaster } from 'react-hot-toast';
+import QueryProvider from '@/providers/QueryProvider';
 
 
 export const metadata: Metadata = {
@@ -21,9 +22,11 @@ export default function RootLayout({
       <body>
         <AuthProvider>
           <LanguageProvider>
-            <Toaster position="top-center" />
-            <Navbar />
-            {children}
+            <QueryProvider>
+              <Toaster position="top-center" />
+              <Navbar />
+              {children}
+            </QueryProvider>
           </LanguageProvider>
         </AuthProvider>
       </body>


### PR DESCRIPTION
## Summary
- add QueryProvider for React Query
- add new `/api/search` endpoint with pagination
- update Firestore queryCreators to support cursors and limits
- refactor discovery components to use `useInfiniteQuery`
- persist map markers across pages

## Testing
- `npx jest --runInBand` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6842dea26c208328a63bbeb3898e60eb