### PR TITLE
Add map-based location filter

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -29,6 +29,7 @@ export default function ExplorePage() {
     searchNearMe: searchParams.get('searchNearMe') === 'true',
     lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : undefined,
     lng: searchParams.get('lng') ? parseFloat(searchParams.get('lng')!) : undefined,
+    radiusKm: searchParams.get('radiusKm') ? parseInt(searchParams.get('radiusKm')!, 10) : 50,
   });
 
   useEffect(() => {
@@ -39,9 +40,10 @@ export default function ExplorePage() {
     if (filters.proTier) query.set('proTier', filters.proTier);
     if (filters.searchNearMe) {
       query.set('searchNearMe', 'true');
-      if (filters.lat) query.set('lat', String(filters.lat));
-      if (filters.lng) query.set('lng', String(filters.lng));
     }
+    if (filters.lat) query.set('lat', String(filters.lat));
+    if (filters.lng) query.set('lng', String(filters.lng));
+    if (filters.radiusKm) query.set('radiusKm', String(filters.radiusKm));
     query.set('view', view);
     router.replace('/explore?' + query.toString());
   }, [filters, view]);

--- a/src/components/explore/FilterPanel.tsx
+++ b/src/components/explore/FilterPanel.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import LocationAutocomplete from './LocationAutocomplete';
+
 type Props = {
   filters: {
     role: string;
@@ -9,6 +11,7 @@ type Props = {
     searchNearMe?: boolean;
     lat?: number;
     lng?: number;
+    radiusKm?: number;
   };
   setFilters: (filters: any) => void;
 };
@@ -58,13 +61,38 @@ export default function FilterPanel({ filters, setFilters }: Props) {
           <option value="engineer">Engineer</option>
         </select>
 
-        <input
-          type="text"
-          placeholder="Location (Tokyo, Seoul...)"
+        <LocationAutocomplete
           value={filters.location}
-          onChange={(e) => setFilters({ ...filters, location: e.target.value })}
-          className="input-base"
+          onChange={(v) => setFilters({ ...filters, location: v })}
+          onSelect={(name, lat, lng) =>
+            setFilters({
+              ...filters,
+              location: name,
+              lat,
+              lng,
+              searchNearMe: false,
+            })
+          }
         />
+
+        <div>
+          <label className="text-sm block mb-1">
+            Radius: {filters.radiusKm ?? 50} km
+          </label>
+          <input
+            type="range"
+            min={1}
+            max={100}
+            value={filters.radiusKm ?? 50}
+            onChange={(e) =>
+              setFilters({
+                ...filters,
+                radiusKm: parseInt(e.target.value, 10),
+              })
+            }
+            className="w-full"
+          />
+        </div>
 
         <input
           type="text"

--- a/src/components/explore/LocationAutocomplete.tsx
+++ b/src/components/explore/LocationAutocomplete.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export default function LocationAutocomplete({
+  value,
+  onChange,
+  onSelect,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onSelect: (name: string, lat: number, lng: number) => void;
+}) {
+  const [query, setQuery] = useState(value);
+  const [results, setResults] = useState<any[]>([]);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+
+  useEffect(() => {
+    setQuery(value);
+  }, [value]);
+
+  useEffect(() => {
+    if (query.length < 2 || !token) {
+      setResults([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    const fetchResults = async () => {
+      try {
+        const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
+          query
+        )}.json?access_token=${token}&autocomplete=true&types=place`;
+        const res = await fetch(url, { signal: controller.signal });
+        const data = await res.json();
+        setResults(data.features || []);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchResults();
+    return () => controller.abort();
+  }, [query, token]);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, []);
+
+  const handleSelect = (item: any) => {
+    setQuery(item.place_name);
+    onChange(item.place_name);
+    onSelect(item.place_name, item.center[1], item.center[0]);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <input
+        type="text"
+        value={query}
+        placeholder="Location (Tokyo, Seoul...)"
+        onChange={(e) => {
+          setQuery(e.target.value);
+          onChange(e.target.value);
+        }}
+        onFocus={() => setOpen(true)}
+        className="input-base"
+      />
+      {open && results.length > 0 && (
+        <ul className="absolute z-10 bg-white text-black border border-gray-300 rounded mt-1 max-h-60 overflow-auto w-full">
+          {results.map((r) => (
+            <li
+              key={r.id}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => handleSelect(r)}
+              className="px-3 py-2 hover:bg-gray-200 cursor-pointer text-sm"
+            >
+              {r.place_name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `LocationAutocomplete` using Mapbox API
- swap the plain location input in `FilterPanel` for the new autocomplete
- add a radius slider and propagate `radiusKm` to filters
- keep query parameters up to date

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842dea0573c83289d4a0a5171ffc070