### PR TITLE
Implement Algolia search fallback and keyword filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/typography": "^0.5.16",
+        "algoliasearch": "^4.22.1",
         "assert": "^2.1.0",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
@@ -66,6 +67,154 @@
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.3.4",
         "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
+      "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/cache-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/cache-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
+      "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g==",
+      "license": "MIT"
+    },
+    "node_modules/@algolia/cache-in-memory": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
+      "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/cache-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-account": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
+      "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+      "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+      "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/logger-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
+      "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA==",
+      "license": "MIT"
+    },
+    "node_modules/@algolia/logger-console": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
+      "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/logger-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+      "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/requester-common": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
+      "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA==",
+      "license": "MIT"
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/requester-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/transporter": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
+      "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6156,6 +6305,29 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+      "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-account": "4.24.0",
+        "@algolia/client-analytics": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-personalization": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/recommend": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "stripe": "^17.7.0",
     "mongoose": "^8.3.1",
     "util": "^0.12.5",
+    "algoliasearch": "^4.22.1",
     "zod": "^3.25.3"
   },
   "devDependencies": {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { algoliaIndex } from '@/lib/search/algolia';
+import { queryCreators } from '@/lib/firestore/queryCreators';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q') || '';
+  const filters: any = {
+    role: searchParams.get('role') || '',
+    location: searchParams.get('location') || '',
+    service: searchParams.get('service') || '',
+    proTier: searchParams.get('proTier') || '',
+  };
+  if (searchParams.get('searchNearMe') === 'true') {
+    filters.searchNearMe = true;
+    if (searchParams.get('lat')) filters.lat = parseFloat(searchParams.get('lat')!);
+    if (searchParams.get('lng')) filters.lng = parseFloat(searchParams.get('lng')!);
+  }
+
+  try {
+    if (q) {
+      const algoliaRes = await algoliaIndex.search(q);
+      if (algoliaRes.hits.length > 0) {
+        return NextResponse.json(algoliaRes.hits);
+      }
+    }
+  } catch (err) {
+    console.error('Algolia search failed:', (err as Error).message);
+  }
+
+  if (q && !filters.service && !filters.role) {
+    const lower = q.toLowerCase();
+    if (lower.includes('engineer')) filters.role = 'engineer';
+    if (lower.includes('artist')) filters.role = 'artist';
+    if (lower.includes('producer')) filters.role = 'producer';
+    if (lower.includes('studio')) filters.role = 'studio';
+    if (lower.includes('videographer')) filters.role = 'videographer';
+    if (lower.includes('mix')) filters.service = 'mixing';
+    if (lower.includes('master')) filters.service = 'mastering';
+  }
+
+  const results = await queryCreators(filters);
+  return NextResponse.json(results);
+}

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -25,6 +25,7 @@ export default function ExplorePage() {
     role: searchParams.get('role') || '',
     location: searchParams.get('location') || '',
     service: searchParams.get('service') || '',
+    keyword: searchParams.get('q') || '',
     proTier: searchParams.get('proTier') || '',
     searchNearMe: searchParams.get('searchNearMe') === 'true',
     lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : undefined,
@@ -36,6 +37,7 @@ export default function ExplorePage() {
     if (filters.role) query.set('role', filters.role);
     if (filters.location) query.set('location', filters.location);
     if (filters.service) query.set('service', filters.service);
+    if (filters.keyword) query.set('q', filters.keyword);
     if (filters.proTier) query.set('proTier', filters.proTier);
     if (filters.searchNearMe) {
       query.set('searchNearMe', 'true');

--- a/src/components/explore/DiscoveryGrid.tsx
+++ b/src/components/explore/DiscoveryGrid.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { queryCreators } from '@/lib/firestore/queryCreators';
 import { getNextAvailable } from '@/lib/firestore/getNextAvailable';
 import { SaveButton } from '@/components/profile/SaveButton';
 import { getAverageRating } from '@/lib/reviews/getAverageRating';
@@ -16,8 +15,20 @@ export default function DiscoveryGrid({ filters }: { filters: any }) {
   const router = useRouter();
 
   useEffect(() => {
-    const fetch = async () => {
-      const results = await queryCreators(filters);
+    const load = async () => {
+      const params = new URLSearchParams();
+      if (filters.role) params.set('role', filters.role);
+      if (filters.location) params.set('location', filters.location);
+      if (filters.service) params.set('service', filters.service);
+      if (filters.keyword) params.set('q', filters.keyword);
+      if (filters.proTier) params.set('proTier', filters.proTier);
+      if (filters.searchNearMe) {
+        params.set('searchNearMe', 'true');
+        if (filters.lat) params.set('lat', String(filters.lat));
+        if (filters.lng) params.set('lng', String(filters.lng));
+      }
+      const res = await fetch('/api/search?' + params.toString());
+      const results = await res.json();
 
       const withMeta = await Promise.all(
         results.map(async (c: any) => {
@@ -33,7 +44,7 @@ export default function DiscoveryGrid({ filters }: { filters: any }) {
       setLoading(false);
     };
 
-    fetch();
+    load();
   }, [filters]);
 
   if (loading) return <div className="text-white">Loading results...</div>;

--- a/src/components/explore/DiscoveryMap.tsx
+++ b/src/components/explore/DiscoveryMap.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 import mapboxgl from 'mapbox-gl';
-import { queryCreators } from '@/lib/firestore/queryCreators';
 import { cityToCoords } from '@/lib/utils/cityToCoords';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
@@ -31,7 +30,19 @@ export default function DiscoveryMap({ filters }: Props) {
     if (!map.current) return;
 
     const load = async () => {
-      const creators = await queryCreators(filters);
+      const params = new URLSearchParams();
+      if (filters.role) params.set('role', filters.role);
+      if (filters.location) params.set('location', filters.location);
+      if (filters.service) params.set('service', filters.service);
+      if (filters.keyword) params.set('q', filters.keyword);
+      if (filters.proTier) params.set('proTier', filters.proTier);
+      if (filters.searchNearMe) {
+        params.set('searchNearMe', 'true');
+        if (filters.lat) params.set('lat', String(filters.lat));
+        if (filters.lng) params.set('lng', String(filters.lng));
+      }
+      const res = await fetch('/api/search?' + params.toString());
+      const creators = await res.json();
       const features: any[] = [];
 
       creators.forEach((c: any) => {

--- a/src/components/explore/FilterPanel.tsx
+++ b/src/components/explore/FilterPanel.tsx
@@ -5,6 +5,7 @@ type Props = {
     role: string;
     location: string;
     service: string;
+    keyword?: string;
     proTier?: 'standard' | 'verified' | 'signature';
     searchNearMe?: boolean;
     lat?: number;
@@ -71,6 +72,14 @@ export default function FilterPanel({ filters, setFilters }: Props) {
           placeholder="Service (Mixing, Videography...)"
           value={filters.service}
           onChange={(e) => setFilters({ ...filters, service: e.target.value })}
+          className="input-base"
+        />
+
+        <input
+          type="text"
+          placeholder="Keyword"
+          value={filters.keyword || ''}
+          onChange={(e) => setFilters({ ...filters, keyword: e.target.value })}
           className="input-base"
         />
 

--- a/src/components/explore/NewExploreGrid.tsx
+++ b/src/components/explore/NewExploreGrid.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { queryCreators } from '@/lib/firestore/queryCreators';
 import { getAverageRating } from '@/lib/reviews/getAverageRating';
 import { getReviewCount } from '@/lib/reviews/getReviewCount';
 import { SaveButton } from '@/components/profile/SaveButton';
@@ -15,8 +14,20 @@ export default function NewExploreGrid({ filters }: { filters: any }) {
   const router = useRouter();
 
   useEffect(() => {
-    const fetch = async () => {
-      const results = await queryCreators(filters);
+    const load = async () => {
+      const params = new URLSearchParams();
+      if (filters.role) params.set('role', filters.role);
+      if (filters.location) params.set('location', filters.location);
+      if (filters.service) params.set('service', filters.service);
+      if (filters.keyword) params.set('q', filters.keyword);
+      if (filters.proTier) params.set('proTier', filters.proTier);
+      if (filters.searchNearMe) {
+        params.set('searchNearMe', 'true');
+        if (filters.lat) params.set('lat', String(filters.lat));
+        if (filters.lng) params.set('lng', String(filters.lng));
+      }
+      const res = await fetch('/api/search?' + params.toString());
+      const results = await res.json();
 
       const withRatings = await Promise.all(
         results.map(async (c: any) => {
@@ -31,7 +42,7 @@ export default function NewExploreGrid({ filters }: { filters: any }) {
       setLoading(false);
     };
 
-    fetch();
+    load();
   }, [filters]);
 
   if (loading) return <div className="text-white">Loading new layout...</div>;

--- a/src/lib/search/algolia.ts
+++ b/src/lib/search/algolia.ts
@@ -1,0 +1,12 @@
+import algoliasearch from 'algoliasearch';
+
+if (!process.env.ALGOLIA_APP_ID || !process.env.ALGOLIA_API_KEY || !process.env.ALGOLIA_INDEX_NAME) {
+  throw new Error('Missing Algolia environment variables');
+}
+
+export const algoliaClient = algoliasearch(
+  process.env.ALGOLIA_APP_ID,
+  process.env.ALGOLIA_API_KEY
+);
+
+export const algoliaIndex = algoliaClient.initIndex(process.env.ALGOLIA_INDEX_NAME);


### PR DESCRIPTION
## Summary
- configure Algolia client
- expose `/api/search` endpoint with Algolia forwarding and Firestore fallback
- support keyword search field in filter panel
- sync search query in explore page URL
- fetch search results from API in grid and map views
- add Algolia dependency

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842de9d0eb48328813d01bce80c7f5b