### PR TITLE
Implement Tier Promotion Logic

### DIFF
--- a/__tests__/verificationPromotion.test.ts
+++ b/__tests__/verificationPromotion.test.ts
@@ -1,0 +1,33 @@
+import { approveUserVerification } from '@/lib/firestore/approveUserVerification'
+import { doc, getDoc, updateDoc } from 'firebase/firestore'
+
+jest.mock('@/lib/firebase', () => ({ db: {} }))
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  updateDoc: jest.fn(),
+}))
+
+const mockedDoc = doc as jest.MockedFunction<typeof doc>
+const mockedGetDoc = getDoc as jest.MockedFunction<typeof getDoc>
+const mockedUpdateDoc = updateDoc as jest.MockedFunction<typeof updateDoc>
+
+describe('approveUserVerification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedDoc.mockReturnValue('ref' as any)
+  })
+
+  test('promotes to verified tier when user has 500+ XP', async () => {
+    mockedGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ points: 600 }) } as any)
+    await approveUserVerification('u1')
+    expect(mockedUpdateDoc).toHaveBeenCalledWith('ref', { verificationStatus: 'verified', proTier: 'verified' })
+  })
+
+  test('does not set tier if user lacks XP', async () => {
+    mockedGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ points: 100 }) } as any)
+    await approveUserVerification('u1')
+    expect(mockedUpdateDoc).toHaveBeenCalledWith('ref', { verificationStatus: 'verified' })
+  })
+})

--- a/src/app/dashboard/admin/verification-requests/page.tsx
+++ b/src/app/dashboard/admin/verification-requests/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { collection, getDocs, updateDoc, doc } from 'firebase/firestore'
+import { collection, getDocs } from 'firebase/firestore'
+import { approveUserVerification } from '@/lib/firestore/approveUserVerification'
 import { db } from '@/lib/firebase'
 
 export default function VerificationRequestsPage() {
@@ -19,10 +20,7 @@ export default function VerificationRequestsPage() {
   }, [])
 
   const approve = async (uid: string) => {
-    await updateDoc(doc(db, 'users', uid), {
-      verificationStatus: 'verified',
-      proTier: 'verified'
-    })
+    await approveUserVerification(uid)
     setRequests(r => r.filter(u => r.id !== uid))
   }
 

--- a/src/app/profile/[uid]/page.tsx
+++ b/src/app/profile/[uid]/page.tsx
@@ -8,6 +8,7 @@ import { ReviewList } from '@/components/reviews/ReviewList';
 import { PortfolioGrid } from '@/components/profile/PortfolioGrid';
 import { SaveButton } from '@/components/profile/SaveButton';
 import { PointsBadge } from '@/components/profile/PointsBadge';
+import { VerifiedProgress } from '@/components/profile/VerifiedProgress';
 import BookingForm from '@/components/booking/BookingForm';
 import { getAverageRating } from '@/lib/reviews/getAverageRating';
 import { getReviewCount } from '@/lib/reviews/getReviewCount';
@@ -65,6 +66,11 @@ export default function PublicProfilePage() {
         </p>
       )}
       <PointsBadge points={profile.points} />
+      <VerifiedProgress
+        points={profile.points}
+        verificationStatus={profile.verificationStatus}
+        proTier={profile.proTier}
+      />
 
       <p className="mb-2 max-w-xl text-center">{profile.bio || 'No bio provided.'}</p>
 

--- a/src/components/admin/AdminVerificationRequests.tsx
+++ b/src/components/admin/AdminVerificationRequests.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { db } from '@/lib/firebase'
 import { collection, getDocs, updateDoc, doc, query, where } from 'firebase/firestore'
+import { approveUserVerification } from '@/lib/firestore/approveUserVerification'
 
 interface Request {
   id: string
@@ -23,10 +24,7 @@ export default function AdminVerificationRequests() {
   }, [])
 
   const approve = async (id: string) => {
-    await updateDoc(doc(db, 'users', id), {
-      verificationStatus: 'verified',
-      proTier: 'verified'
-    })
+    await approveUserVerification(id)
     setRequests(r => r.filter(req => req.id !== id))
   }
 

--- a/src/components/profile/VerifiedProgress.tsx
+++ b/src/components/profile/VerifiedProgress.tsx
@@ -1,0 +1,12 @@
+export function VerifiedProgress({ points, verificationStatus, proTier }: { points?: number; verificationStatus?: string; proTier?: string }) {
+  if (proTier === 'verified') return null
+
+  const progress = Math.min(points || 0, 500)
+  const remaining = 500 - progress
+
+  return (
+    <p className="text-sm text-gray-400" title="XP progress toward Verified tier">
+      {progress}/{500} XP {verificationStatus === 'verified' ? '(awaiting promotion)' : ''}
+    </p>
+  )
+}

--- a/src/lib/firestore/approveUserVerification.ts
+++ b/src/lib/firestore/approveUserVerification.ts
@@ -1,0 +1,19 @@
+import { db } from '@/lib/firebase'
+import { doc, getDoc, updateDoc } from 'firebase/firestore'
+
+/**
+ * Approve a user's ID verification request. If the user has at least
+ * 500 XP, they are promoted to the verified pro tier.
+ */
+export async function approveUserVerification(uid: string) {
+  const ref = doc(db, 'users', uid)
+  const snap = await getDoc(ref)
+  const points = snap.exists() ? (snap.data() as any).points || 0 : 0
+
+  const updates: any = { verificationStatus: 'verified' }
+  if (points >= 500) {
+    updates.proTier = 'verified'
+  }
+  await updateDoc(ref, updates)
+  return updates
+}


### PR DESCRIPTION
## Summary
- add helper to approve user verification with XP check
- display verified XP progress on profiles
- use helper in admin verification screens
- test tier promotion rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842da5a28788328b7e3195ecba7e0db