### PR TITLE
Add saved filter presets

### DIFF
--- a/src/components/explore/FilterPanel.tsx
+++ b/src/components/explore/FilterPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import LocationAutocomplete from './LocationAutocomplete';
+import SavedFilters from './SavedFilters';
 
 type Props = {
   filters: {
@@ -48,6 +49,7 @@ export default function FilterPanel({ filters, setFilters }: Props) {
       <h2 className="font-semibold mb-4 text-lg">Filters</h2>
 
       <div className="flex flex-col gap-4">
+        <SavedFilters filters={filters} setFilters={setFilters} />
         <select
           value={filters.role}
           onChange={(e) => setFilters({ ...filters, role: e.target.value })}

--- a/src/components/explore/SavedFilters.tsx
+++ b/src/components/explore/SavedFilters.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/lib/hooks/useAuth';
+import {
+  createFilterPreset,
+  fetchFilterPresets,
+  deleteFilterPreset,
+  SavedFilter,
+} from '@/lib/firestore/savedFilters';
+
+export default function SavedFilters({
+  filters,
+  setFilters,
+}: {
+  filters: any;
+  setFilters: (f: any) => void;
+}) {
+  const { user } = useAuth();
+  const [presets, setPresets] = useState<SavedFilter[]>([]);
+  const [selected, setSelected] = useState('');
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+    fetchFilterPresets(user.uid).then(setPresets);
+  }, [user]);
+
+  const applyPreset = (id: string) => {
+    const preset = presets.find(p => p.id === id);
+    if (!preset) return;
+    setFilters({ ...filters, ...preset.filters });
+  };
+
+  const savePreset = async () => {
+    if (!user || !name.trim()) return;
+    await createFilterPreset(user.uid, name.trim(), filters);
+    const list = await fetchFilterPresets(user.uid);
+    setPresets(list);
+    setName('');
+  };
+
+  const deletePresetHandler = async () => {
+    if (!user || !selected) return;
+    await deleteFilterPreset(user.uid, selected);
+    const list = await fetchFilterPresets(user.uid);
+    setPresets(list);
+    setSelected('');
+  };
+
+  const handleSelect = (id: string) => {
+    setSelected(id);
+    if (id) applyPreset(id);
+  };
+
+  return (
+    <div className="space-y-2">
+      <select
+        value={selected}
+        onChange={e => handleSelect(e.target.value)}
+        className="input-base"
+      >
+        <option value="">Saved Presets</option>
+        {presets.map(p => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          placeholder="Preset name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          className="input-base flex-1"
+        />
+        <button onClick={savePreset} className="btn btn-primary">
+          Save
+        </button>
+        {selected && (
+          <button onClick={deletePresetHandler} className="btn btn-secondary">
+            Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/firestore/savedFilters.ts
+++ b/src/lib/firestore/savedFilters.ts
@@ -1,0 +1,28 @@
+import { getFirestore, collection, addDoc, getDocs, deleteDoc, doc, serverTimestamp } from 'firebase/firestore';
+import { app } from '@/lib/firebase';
+
+export type SavedFilter = {
+  id: string;
+  name: string;
+  filters: Record<string, any>;
+};
+
+export async function createFilterPreset(uid: string, name: string, filters: Record<string, any>) {
+  const db = getFirestore(app);
+  await addDoc(collection(db, 'users', uid, 'savedFilters'), {
+    name,
+    filters,
+    createdAt: serverTimestamp(),
+  });
+}
+
+export async function fetchFilterPresets(uid: string): Promise<SavedFilter[]> {
+  const db = getFirestore(app);
+  const snap = await getDocs(collection(db, 'users', uid, 'savedFilters'));
+  return snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<SavedFilter, 'id'>) }));
+}
+
+export async function deleteFilterPreset(uid: string, presetId: string) {
+  const db = getFirestore(app);
+  await deleteDoc(doc(db, 'users', uid, 'savedFilters', presetId));
+}


### PR DESCRIPTION
## Summary
- add Firestore utils to store filter presets
- provide SavedFilters dropdown component
- embed SavedFilters in the explore FilterPanel

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448720999c83289ddf990d6eb1008d