### PR TITLE
Add Polish translations

### DIFF
--- a/src/components/ui/LanguageSwitcher.tsx
+++ b/src/components/ui/LanguageSwitcher.tsx
@@ -9,6 +9,7 @@ export default function LanguageSwitcher() {
     { code: 'en', label: 'EN' },
     { code: 'jp', label: 'JP' },
     { code: 'kr', label: 'KR' },
+    { code: 'pl', label: 'PL' },
   ];
 
   return (

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState } from 'react';
 
-type Language = 'en' | 'jp' | 'kr';
+type Language = 'en' | 'jp' | 'kr' | 'pl';
 
 const LanguageContext = createContext<{
   language: Language;

--- a/src/i18n/Translate.tsx
+++ b/src/i18n/Translate.tsx
@@ -4,11 +4,13 @@ import { useLanguage } from '@/context/LanguageContext';
 import en from '@/i18n/en.json';
 import jp from '@/i18n/jp.json';
 import kr from '@/i18n/kr.json';
+import pl from '@/i18n/pl.json';
 
 const translations: Record<string, Record<string, string>> = {
   en,
   jp,
   kr,
+  pl,
 };
 
 export function Translate({ t }: { t: string }) {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,0 +1,22 @@
+{
+  "nav.explore": "Odkrywaj",
+  "nav.apply": "Aplikuj",
+  "nav.login": "Zaloguj się",
+  "nav.dashboard": "Panel",
+  "nav.logout": "Wyloguj",
+  "dashboard.selling": "Sprzedaję",
+  "dashboard.buying": "Kupuję",
+  "sidebar.dashboardHome": "Strona główna panelu",
+  "sidebar.bookings": "Rezerwacje",
+  "sidebar.messages": "Wiadomości",
+  "sidebar.availability": "Dostępność",
+  "sidebar.finances": "Finanse",
+  "sidebar.profile": "Profil",
+  "sidebar.settings": "Ustawienia",
+  "bottomnav.home": "Główna",
+  "bottomnav.messages": "Wiadomości",
+  "bottomnav.bookings": "Rezerwacje",
+  "bottomnav.profile": "Profil",
+  "button.saveChanges": "Zapisz zmiany",
+  "button.submitService": "Dodaj usługę"
+}


### PR DESCRIPTION
## Summary
- add Polish language JSON
- import and register Polish translations
- allow Polish selection in language switcher
- extend LanguageContext types with Polish

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68448e6c6ce48328acffdb7ac41e067b