### PR TITLE
Fix QueryProvider import

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { Metadata } from 'next';
 import { LanguageProvider } from '@/context/LanguageContext';
 import { AuthProvider } from '@/context/AuthContext';
 import { Toaster } from 'react-hot-toast';
-import QueryProvider from '@/providers/QueryProvider';
+import QueryProvider from '../../providers/QueryProvider';
 
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary
- fix import path for QueryProvider in layout to use relative path

## Testing
- `npm test`
- `npm run build` *(fails: missing default export in firebase-admin, invalid default export from dashboard/artist page)*


------
https://chatgpt.com/codex/tasks/task_e_68451e6339688328a19033b379f72bbd