### PR TITLE
Add signature contact-only gate

### DIFF
--- a/lib/getUserProfile.ts
+++ b/lib/getUserProfile.ts
@@ -8,7 +8,13 @@ export const getUserProfile = async (uid: string) => {
   try {
     const userRef = doc(db, "users", uid);
     const userSnap = await getDoc(userRef);
-    return userSnap.exists() ? userSnap.data() : null;
+    if (!userSnap.exists()) return null;
+
+    const data = userSnap.data();
+    return {
+      ...data,
+      contactOnlyViaRequest: data.contactOnlyViaRequest ?? false,
+    };
   } catch (error) {
     logger.error("Error fetching user profile:", error);
     return null;

--- a/src/app/profile/[uid]/page.tsx
+++ b/src/app/profile/[uid]/page.tsx
@@ -10,6 +10,7 @@ import { SaveButton } from '@/components/profile/SaveButton';
 import { PointsBadge } from '@/components/profile/PointsBadge';
 import { VerifiedProgress } from '@/components/profile/VerifiedProgress';
 import BookingForm from '@/components/booking/BookingForm';
+import ProfileActionBar from '@/components/profile/ProfileActionBar';
 import { getAverageRating } from '@/lib/reviews/getAverageRating';
 import { getReviewCount } from '@/lib/reviews/getReviewCount';
 
@@ -38,12 +39,6 @@ export default function PublicProfilePage() {
     fetchProfile();
   }, [uid]);
 
-  const scrollToBooking = () => {
-    const form = document.getElementById('booking-form');
-    if (form) {
-      form.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  };
 
   if (loading) return <div className="p-6 text-white">Loading...</div>;
   if (!profile) return <div className="p-6 text-white">Profile not found.</div>;
@@ -119,14 +114,13 @@ export default function PublicProfilePage() {
         <ReviewList uid={uid} />
       </div>
 
-      <div className="fixed bottom-4 inset-x-0 flex justify-center md:hidden z-50">
-        <button
-          onClick={scrollToBooking}
-          className="bg-white text-black font-semibold px-6 py-3 rounded-full shadow-lg border border-black"
-        >
-          📩 Request Booking
-        </button>
-      </div>
+      <ProfileActionBar
+        profile={{
+          uid,
+          proTier: profile.proTier,
+          contactOnlyViaRequest: profile.contactOnlyViaRequest,
+        }}
+      />
     </div>
   );
 }

--- a/src/components/profile/ProfileActionBar.tsx
+++ b/src/components/profile/ProfileActionBar.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useAuth } from '@/lib/hooks/useAuth';
+
+export default function ProfileActionBar({
+  profile,
+}: {
+  profile: { uid: string; proTier?: string; contactOnlyViaRequest?: boolean };
+}) {
+  const { user } = useAuth();
+  const isOwner = user?.uid === profile.uid;
+  const locked =
+    profile.proTier === 'signature' && profile.contactOnlyViaRequest && !isOwner;
+
+  const scrollToBooking = () => {
+    const form = document.getElementById('booking-form');
+    if (form) form.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <div className="fixed bottom-4 inset-x-0 flex justify-center md:hidden z-50">
+      <button
+        onClick={locked ? undefined : scrollToBooking}
+        disabled={locked}
+        title={
+          locked ? 'Invite-only artist – contact via manager.' : 'Request Booking'
+        }
+        aria-label="Request booking"
+        className={`btn btn-primary ${locked ? 'cursor-not-allowed opacity-60' : ''}`}
+      >
+        📩 Request Booking
+      </button>
+    </div>
+  );
+}

--- a/src/lib/firestore/getUserProfile.ts
+++ b/src/lib/firestore/getUserProfile.ts
@@ -1,0 +1,12 @@
+import { db } from '@/lib/firebase';
+import { doc, getDoc } from 'firebase/firestore';
+
+export async function getUserProfile(uid: string) {
+  const snap = await getDoc(doc(db, 'users', uid));
+  if (!snap.exists()) return null;
+  const data = snap.data();
+  return {
+    ...data,
+    contactOnlyViaRequest: data.contactOnlyViaRequest ?? false,
+  };
+}


### PR DESCRIPTION
## Summary
- ensure `contactOnlyViaRequest` is returned by `getUserProfile`
- expose Firestore utility at `src/lib/firestore/getUserProfile.ts`
- add `ProfileActionBar` component with invite-only tooltip logic
- use `ProfileActionBar` on public profile page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452093e83c8328bc5e3ce504b761ba