### PR TITLE
Add scheduled streak reset Cloud Function

### DIFF
--- a/functions/src/cron/streakReset.ts
+++ b/functions/src/cron/streakReset.ts
@@ -1,0 +1,14 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+admin.initializeApp();
+
+export const resetResponsiveStreak = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(async () => {
+    const batch = admin.firestore().batch();
+    const users = await admin.firestore().collection('users').get();
+    users.forEach((doc) => {
+      batch.update(doc.ref, { streakCount: 0 });
+    });
+    await batch.commit();
+  });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,1 @@
+export * from './cron/streakReset';


### PR DESCRIPTION
## Summary
- add cron function to reset responsive streak counts
- export new scheduled function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68453c33cc9c8328bb1da3dc0874c5fe