### PR TITLE
Improve map UX and favorites feedback

### DIFF
--- a/src/components/explore/DiscoveryMap.tsx
+++ b/src/components/explore/DiscoveryMap.tsx
@@ -65,6 +65,9 @@ export default function DiscoveryMap({ filters }: Props) {
         style: 'mapbox://styles/mapbox/dark-v10',
         center: [139.6917, 35.6895], // Tokyo default
         zoom: 2,
+        dragPan: true,
+        touchPitch: false,
+        touchZoomRotate: false,
       });
     }
   }, []);

--- a/src/components/explore/SaveButton.tsx
+++ b/src/components/explore/SaveButton.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/lib/hooks/useAuth'
 import { AiOutlineStar, AiFillStar } from 'react-icons/ai'
 import { doc, getDoc } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
+import toast from 'react-hot-toast'
 
 type Props = {
   creatorId: string
@@ -37,6 +38,7 @@ const SaveButton = ({ creatorId }: Props) => {
     const newState = !saved
     setSaved(newState)
     await toggleFavorite(user.uid, creatorId, newState)
+    if (newState) toast.success('Added to favorites')
   }
 
   return (

--- a/src/components/profile/SaveButton.tsx
+++ b/src/components/profile/SaveButton.tsx
@@ -5,6 +5,7 @@ import { doc, getDoc, setDoc, deleteDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useAuth } from '@/lib/hooks/useAuth';
 import { AiOutlineStar, AiFillStar } from 'react-icons/ai';
+import toast from 'react-hot-toast';
 import { Translate } from '@/i18n/Translate';
 
 export function SaveButton({ providerId }: { providerId: string }) {
@@ -33,6 +34,7 @@ export function SaveButton({ providerId }: { providerId: string }) {
     } else {
       await setDoc(ref, { savedAt: new Date() });
       setIsSaved(true);
+      toast.success('Added to favorites');
     }
   };
 


### PR DESCRIPTION
## Summary
- add toast feedback when saving a favorite
- show same toast in explore save button
- tweak mapbox options for smoother touch interaction

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68453f130be48328a077ffa74da5c857