### PR TITLE
Implement booking UI improvements

### DIFF
--- a/src/app/components/dashboard/SlotSelectorGrid.tsx
+++ b/src/app/components/dashboard/SlotSelectorGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useRef } from 'react';
 import { DateTime } from 'luxon';
 
 type Slot = { day: string; time: string };
@@ -41,6 +41,7 @@ export default function SlotSelectorGrid({
   toggleSlot,
   originalTimezone,
 }: Props) {
+  const touchRef = useRef(false);
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full table-auto border-collapse">
@@ -72,7 +73,17 @@ export default function SlotSelectorGrid({
                   <td key={day + time}>
                     <button
                       disabled={isBusy}
-                      onClick={() => toggleSlot({ day, time })}
+                      onTouchEnd={() => {
+                        touchRef.current = true;
+                        toggleSlot({ day, time });
+                      }}
+                      onClick={() => {
+                        if (touchRef.current) {
+                          touchRef.current = false;
+                          return;
+                        }
+                        toggleSlot({ day, time });
+                      }}
                       className={`${baseClass} ${
                         isBusy ? busyClass : isSelected ? selectedClass : emptyClass
                       }`}

--- a/src/app/legal/escrow/page.tsx
+++ b/src/app/legal/escrow/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+export default function EscrowTermsPage() {
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <div className="max-w-2xl mx-auto space-y-4">
+        <h1 className="text-3xl font-bold">Escrow Terms & Refund Policy</h1>
+        <p>
+          All payments are held in escrow until both client and provider confirm the work
+          has been completed. If a dispute arises, funds may be refunded according to our
+          guidelines. Please review the full policy below.
+        </p>
+        <p>
+          Refund requests must be submitted within 7 days of the scheduled completion date.
+          Approved refunds will be returned to the original payment method.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/book/BookingSidebar.tsx
+++ b/src/components/book/BookingSidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import TierBadge from '@/components/ui/TierBadge';
+import Link from 'next/link';
 
 export default function BookingSidebar({
   name,
@@ -27,6 +28,11 @@ export default function BookingSidebar({
       <div className="bg-neutral-800 text-sm p-3 rounded-lg mt-4 border border-neutral-700">
         🛡 Protected by <strong>AuditoryX Guarantee</strong><br />
         Your payment is only released after the creator completes your order.
+        <div className="mt-2">
+          <Link href="/legal/escrow" className="underline text-blue-400 text-xs" target="_blank">
+            Terms & Refund Policy
+          </Link>
+        </div>
       </div>
     </aside>
   );

--- a/src/components/booking/BookingChat.tsx
+++ b/src/components/booking/BookingChat.tsx
@@ -34,8 +34,21 @@ export default function BookingChat({ bookingId }: Props) {
   const [text, setText] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [isTyping, setTyping] = useState(false);
+  const [isOnline, setIsOnline] = useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true
+  );
   const bottomRef = useRef<HTMLDivElement>(null);
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const update = () => setIsOnline(navigator.onLine);
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
 
   useEffect(() => {
     if (!bookingId) return;
@@ -94,6 +107,11 @@ export default function BookingChat({ bookingId }: Props) {
 
   return (
     <div className="space-y-4">
+      {!isOnline && (
+        <div className="bg-red-600 text-white text-center text-xs p-1 rounded">
+          You're offline
+        </div>
+      )}
       <div className="h-64 overflow-y-auto border rounded p-2 bg-white text-black">
         {messages.map(msg => (
           <div

--- a/src/components/booking/BookingSummarySidebar.tsx
+++ b/src/components/booking/BookingSummarySidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import TierBadge from '@/components/ui/TierBadge';
+import { useState } from 'react';
 
 export default function BookingSummarySidebar({
   providerName,
@@ -18,6 +19,7 @@ export default function BookingSummarySidebar({
   platformFee: number;
 }) {
   const total = baseAmount + platformFee;
+  const [showTerms, setShowTerms] = useState(false);
 
   return (
     <div className="bg-neutral-900 border border-neutral-800 p-6 rounded-xl text-white space-y-4">
@@ -43,6 +45,32 @@ export default function BookingSummarySidebar({
         ✔ Your payment is held securely and released only when the session is completed.
         This is protected under the AuditoryX Guarantee.
       </div>
+      <button
+        type="button"
+        onClick={() => setShowTerms(true)}
+        className="text-xs underline text-blue-400 mt-1"
+      >
+        Terms & Refund Policy
+      </button>
+
+      {showTerms && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white text-black p-4 rounded max-w-sm">
+            <h2 className="text-lg font-bold mb-2">Escrow Terms</h2>
+            <p className="text-sm mb-4">
+              Funds are held in escrow until both parties confirm the work is completed. Refunds are issued according to our policy.
+            </p>
+            <a href="/legal/escrow" className="text-blue-600 underline text-sm" target="_blank" rel="noopener noreferrer">
+              View full policy
+            </a>
+            <div className="mt-4 text-right">
+              <button onClick={() => setShowTerms(false)} className="btn btn-primary px-3 py-1 text-sm">
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- handle offline status in chat
- debounce slot taps on iOS via onTouchEnd
- add Terms & Refund policy modal with link
- expose legal escrow page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68453f5db41c8328bb981c0b1989af9a