### PR TITLE
Add profile rating distribution chart

### DIFF
--- a/src/app/profile/[uid]/page.tsx
+++ b/src/app/profile/[uid]/page.tsx
@@ -13,12 +13,15 @@ import BookingForm from '@/components/booking/BookingForm';
 import ProfileActionBar from '@/components/profile/ProfileActionBar';
 import { getAverageRating } from '@/lib/reviews/getAverageRating';
 import { getReviewCount } from '@/lib/reviews/getReviewCount';
+import { getRatingDistribution } from '@/lib/reviews/getRatingDistribution';
+import RatingBarChart from '@/components/profile/RatingBarChart';
 
 export default function PublicProfilePage() {
   const rawParams = useParams();
   const uid = typeof rawParams.uid === 'string' ? rawParams.uid : Array.isArray(rawParams.uid) ? rawParams.uid[0] : '';
   const [profile, setProfile] = useState<any>(null);
   const [loading, setLoading] = useState(true);
+  const [distribution, setDistribution] = useState<Record<number, number> | null>(null);
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -30,8 +33,10 @@ export default function PublicProfilePage() {
         const data = snap.data();
         const avg = await getAverageRating(uid);
         const count = await getReviewCount(uid);
+        const dist = await getRatingDistribution(uid);
 
         setProfile({ ...data, averageRating: avg, reviewCount: count });
+        setDistribution(dist);
       }
 
       setLoading(false);
@@ -55,10 +60,13 @@ export default function PublicProfilePage() {
       )}
 
       {profile.averageRating !== undefined && (
-        <p className="text-yellow-400 text-sm mb-2">
-          ⭐ {profile.averageRating.toFixed(1)} / 5.0
-          <span className="text-gray-400"> ({profile.reviewCount} reviews)</span>
-        </p>
+        <div className="mb-2">
+          <p className="text-yellow-400 text-sm">
+            ⭐ {profile.averageRating.toFixed(1)} / 5.0
+            <span className="text-gray-400"> ({profile.reviewCount} reviews)</span>
+          </p>
+          {distribution && <RatingBarChart distribution={distribution} />}
+        </div>
       )}
       <PointsBadge points={profile.points} />
       <VerifiedProgress

--- a/src/components/profile/RatingBarChart.tsx
+++ b/src/components/profile/RatingBarChart.tsx
@@ -1,0 +1,27 @@
+'use client';
+import React from 'react';
+
+interface RatingBarChartProps {
+  distribution: Record<number, number>;
+}
+
+export default function RatingBarChart({ distribution }: RatingBarChartProps) {
+  const max = Math.max(...Object.values(distribution));
+  return (
+    <div className="space-y-1 mt-2">
+      {([5, 4, 3, 2, 1] as const).map((star) => {
+        const count = distribution[star] || 0;
+        const width = max ? (count / max) * 100 : 0;
+        return (
+          <div key={star} className="flex items-center gap-2 text-sm">
+            <span className="w-10 text-right">{star}★</span>
+            <div className="flex-1 bg-gray-700 rounded">
+              <div className="bg-yellow-400 h-2 rounded" style={{ width: `${width}%` }} />
+            </div>
+            <span className="w-6 text-right">{count}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/reviews/__tests__/getRatingDistribution.test.ts
+++ b/src/lib/reviews/__tests__/getRatingDistribution.test.ts
@@ -1,0 +1,30 @@
+import { getRatingDistribution } from '../getRatingDistribution';
+import { getDocs } from 'firebase/firestore';
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(),
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  getDocs: jest.fn(),
+}));
+
+const mockedGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
+
+describe('getRatingDistribution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns distribution of ratings', async () => {
+    const docs = [
+      { data: () => ({ rating: 5 }) },
+      { data: () => ({ rating: 4 }) },
+      { data: () => ({ rating: 5 }) },
+      { data: () => ({ rating: 3 }) },
+    ];
+    mockedGetDocs.mockResolvedValue({ docs } as any);
+    const dist = await getRatingDistribution('provider');
+    expect(dist).toEqual({ 1: 0, 2: 0, 3: 1, 4: 1, 5: 2 });
+  });
+});

--- a/src/lib/reviews/getRatingDistribution.ts
+++ b/src/lib/reviews/getRatingDistribution.ts
@@ -1,0 +1,16 @@
+import { getFirestore, collection, query, where, getDocs } from 'firebase/firestore';
+import { app } from '@/lib/firebase';
+
+export async function getRatingDistribution(providerId: string): Promise<Record<number, number>> {
+  const db = getFirestore(app);
+  const q = query(collection(db, 'reviews'), where('providerId', '==', providerId));
+  const snap = await getDocs(q);
+  const distribution: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  for (const doc of snap.docs) {
+    const rating = doc.data().rating;
+    if (typeof rating === 'number' && rating >= 1 && rating <= 5) {
+      distribution[rating] = (distribution[rating] || 0) + 1;
+    }
+  }
+  return distribution;
+}


### PR DESCRIPTION
## Summary
- visualize rating distribution by star
- fetch rating distribution on profile page
- display rating chart below average rating
- test rating distribution helper

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68453f8bab0c83288d6f704698d18b95