### PR TITLE
Implement streak celebration toast

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { LanguageProvider } from '@/context/LanguageContext';
 import { AuthProvider } from '@/context/AuthContext';
 import { Toaster } from 'react-hot-toast';
 import QueryProvider from '../../providers/QueryProvider';
+import StreakToast from '../components/gamification/StreakToast';
 
 
 export const metadata: Metadata = {
@@ -24,6 +25,7 @@ export default function RootLayout({
           <LanguageProvider>
             <QueryProvider>
               <Toaster position="top-center" />
+              <StreakToast />
               <Navbar />
               {children}
             </QueryProvider>

--- a/src/components/gamification/StreakToast.tsx
+++ b/src/components/gamification/StreakToast.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useEffect } from 'react'
+import toast from 'react-hot-toast'
+import { useAuth } from '@/lib/hooks/useAuth'
+
+export default function StreakToast() {
+  const { userData } = useAuth()
+
+  useEffect(() => {
+    const streak = userData?.streakCount || 0
+    if (streak < 7 || streak % 7 !== 0) return
+    const last = Number(localStorage.getItem('celebratedStreak') || '0')
+    if (streak !== last) {
+      toast.success(`⚡ ${streak}-day streak! +50 XP`)
+      localStorage.setItem('celebratedStreak', String(streak))
+    }
+  }, [userData?.streakCount])
+
+  return null
+}

--- a/src/components/profile/PointsBadge.tsx
+++ b/src/components/profile/PointsBadge.tsx
@@ -7,6 +7,7 @@ export function PointsBadge({ points = 0 }: { points: number }) {
   return (
     <span
       aria-label={label}
+      title="Earn XP by collaborating and completing bookings"
       className={`inline-block px-2 py-0.5 rounded text-xs text-white ${color}`}
     >
       {label}


### PR DESCRIPTION
## Summary
- add tooltip to PointsBadge
- show toast on 7-day streak milestones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68453fa9152c8328908fa26a57342a8c