### PR TITLE
Improve Google Calendar sync toast

### DIFF
--- a/src/app/components/dashboard/AvailabilityEditor.tsx
+++ b/src/app/components/dashboard/AvailabilityEditor.tsx
@@ -76,7 +76,19 @@ export default function AvailabilityEditor() {
     });
 
     if (res.ok) {
-      toast.success('Pushed availability to Google Calendar!');
+      toast.success(
+        <span>
+          Pushed to Google Calendar.{' '}
+          <a
+            href="https://calendar.google.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Manage on Google
+          </a>
+        </span>
+      );
     } else {
       toast.error('Failed to push to Google Calendar');
     }


### PR DESCRIPTION
## Summary
- add link to Google Calendar in sync success toast in `AvailabilityEditor`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68453ff07c30832884ace45c7829665a