### PR TITLE
Add read receipts and day dividers to messaging

### DIFF
--- a/src/lib/firestore/chat/markConversationMessagesAsSeen.ts
+++ b/src/lib/firestore/chat/markConversationMessagesAsSeen.ts
@@ -1,0 +1,32 @@
+import {
+  getFirestore,
+  doc,
+  updateDoc,
+  collection,
+  getDocs,
+  query,
+  orderBy,
+  limit
+} from 'firebase/firestore'
+import { app } from '@/lib/firebase'
+
+export async function markConversationMessagesAsSeen(convoId: string, uid: string) {
+  const db = getFirestore(app)
+  const q = query(
+    collection(db, 'conversations', convoId, 'messages'),
+    orderBy('timestamp', 'desc'),
+    limit(50)
+  )
+  const snap = await getDocs(q)
+
+  const updates = snap.docs.filter(d => {
+    const data = d.data()
+    return !data.seenBy?.includes(uid)
+  })
+
+  for (const docRef of updates) {
+    await updateDoc(doc(db, 'conversations', convoId, 'messages', docRef.id), {
+      seenBy: [...(docRef.data().seenBy || []), uid]
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- show read receipts and day separators in `MessageCenter`
- track message read status with `markConversationMessagesAsSeen`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68453f6eef7c83289e33df6a0c2f23a9