### PR TITLE
Add role badges to explore views

### DIFF
--- a/__tests__/RoleBadge.test.ts
+++ b/__tests__/RoleBadge.test.ts
@@ -1,0 +1,22 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RoleBadge } from '@/components/explore/RoleBadge';
+
+describe('RoleBadge', () => {
+  const profile = {
+    rooms: 3,
+    travel: 'Worldwide',
+    genre: 'Hip Hop',
+    daw: 'Ableton',
+    mix: 'Analog',
+  };
+
+  (['studio','videographer','artist','producer','engineer'] as const).forEach(role => {
+    test(`renders ${role} emoji`, () => {
+      const html = renderToStaticMarkup(
+        React.createElement(RoleBadge, { role, profile })
+      );
+      expect(html).toMatchSnapshot();
+    });
+  });
+});

--- a/__tests__/__snapshots__/RoleBadge.test.ts.snap
+++ b/__tests__/__snapshots__/RoleBadge.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RoleBadge renders artist emoji 1`] = `"<span class="inline-block text-xs text-gray-400 mb-1">🎤 Hip Hop Genre</span>"`;
+
+exports[`RoleBadge renders engineer emoji 1`] = `"<span class="inline-block text-xs text-gray-400 mb-1">🎚️ Analog Mix</span>"`;
+
+exports[`RoleBadge renders producer emoji 1`] = `"<span class="inline-block text-xs text-gray-400 mb-1">🎛️ Ableton DAW</span>"`;
+
+exports[`RoleBadge renders studio emoji 1`] = `"<span class="inline-block text-xs text-gray-400 mb-1">🏢 3 Rooms</span>"`;
+
+exports[`RoleBadge renders videographer emoji 1`] = `"<span class="inline-block text-xs text-gray-400 mb-1">🎥 Worldwide Travel</span>"`;

--- a/src/components/explore/DiscoveryMap.tsx
+++ b/src/components/explore/DiscoveryMap.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from '@/context/LanguageContext';
 import en from '@/i18n/en.json';
 import jp from '@/i18n/jp.json';
 import kr from '@/i18n/kr.json';
+import { roleBadges, RoleKey } from '@/constants/roleBadges';
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN!;
 
@@ -208,10 +209,19 @@ export default function DiscoveryMap({ filters }: Props) {
           const viewLabel =
             translations[language]?.['common.viewProfile'] || 'View Profile';
 
+          const badgeCfg = roleBadges[props.role as RoleKey];
+          const key = badgeCfg?.label.toLowerCase();
+          const metric = key ? (props as any)[key] : null;
+          const badgeHtml =
+            badgeCfg && metric
+              ? `${badgeCfg.icon} ${metric} ${badgeCfg.label}<br/>`
+              : '';
+
           const html =
             `<div style="font-size:14px">` +
             `<strong>${props.name}</strong><br/>` +
             `${props.role}${props.verified ? ' ✔️' : ''}<br/>` +
+            badgeHtml +
             `<a href="/profile/${props.uid}" target="_blank" class="underline text-blue-400">${viewLabel}</a>` +
             `</div>`;
 

--- a/src/components/explore/NewExploreGrid.tsx
+++ b/src/components/explore/NewExploreGrid.tsx
@@ -8,6 +8,7 @@ import { getReviewCount } from '@/lib/reviews/getReviewCount';
 import { SaveButton } from '@/components/profile/SaveButton';
 import { getProfileCompletion } from '@/lib/profile/getProfileCompletion';
 import { PointsBadge } from '@/components/profile/PointsBadge';
+import { RoleBadge } from '@/components/explore/RoleBadge';
 import { Translate } from '@/i18n/Translate';
 
 export default function NewExploreGrid({ filters }: { filters: any }) {
@@ -94,6 +95,9 @@ export default function NewExploreGrid({ filters }: { filters: any }) {
           <p className="text-xs text-blue-400">
             📊 {c.completion}% Profile Complete
           </p>
+
+          {/* Role specific metric */}
+          <RoleBadge role={c.role} profile={c} />
 
           {/* XP / gamification badge */}
           <PointsBadge points={c.points} />

--- a/src/components/explore/RoleBadge.tsx
+++ b/src/components/explore/RoleBadge.tsx
@@ -1,0 +1,22 @@
+'use client';
+import React from 'react';
+import { roleBadges, RoleKey } from '@/constants/roleBadges';
+
+export function RoleBadge({
+  role,
+  profile,
+}: {
+  role: string;
+  profile: Record<string, any>;
+}) {
+  const cfg = roleBadges[role as RoleKey];
+  if (!cfg) return null;
+  const key = cfg.label.toLowerCase();
+  const value = profile?.[key];
+  if (value === undefined || value === null || value === '') return null;
+  return React.createElement(
+    'span',
+    { className: 'inline-block text-xs text-gray-400 mb-1' },
+    `${cfg.icon} ${value} ${cfg.label}`
+  );
+}

--- a/src/constants/roleBadges.ts
+++ b/src/constants/roleBadges.ts
@@ -1,0 +1,9 @@
+export const roleBadges = {
+  studio: { icon: '🏢', label: 'Rooms' },
+  videographer: { icon: '🎥', label: 'Travel' },
+  artist: { icon: '🎤', label: 'Genre' },
+  producer: { icon: '🎛️', label: 'DAW' },
+  engineer: { icon: '🎚️', label: 'Mix' },
+} as const;
+
+export type RoleKey = keyof typeof roleBadges;


### PR DESCRIPTION
## Summary
- define role badges with icons and labels
- add `RoleBadge` component
- show role metric in explore grid cards
- include badge in map popups
- test rendering of role badges

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6845436c2e708328b34931b0bd4fa8f0