### PR TITLE
Seed service templates on profile create

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,1 +1,2 @@
 export * from './cron/streakReset';
+export * from './triggers/onProfileCreate';

--- a/functions/src/triggers/onProfileCreate.ts
+++ b/functions/src/triggers/onProfileCreate.ts
@@ -1,0 +1,44 @@
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+export const onProfileCreate = functions.firestore
+  .document('users/{uid}')
+  .onCreate(async (snap, context) => {
+    const data = snap.data();
+    const role = data?.role;
+
+    if (!role) {
+      console.log('No role found for user', context.params.uid);
+      return null;
+    }
+
+    const templatesSnap = await admin
+      .firestore()
+      .collection('serviceTemplates')
+      .doc(role)
+      .collection('templates')
+      .get();
+
+    if (templatesSnap.empty) {
+      console.log(`No templates for role ${role}`);
+      return null;
+    }
+
+    const batch = admin.firestore().batch();
+    templatesSnap.forEach((doc) => {
+      const dest = admin
+        .firestore()
+        .collection('users')
+        .doc(context.params.uid)
+        .collection('services')
+        .doc(doc.id);
+      batch.set(dest, doc.data());
+    });
+
+    await batch.commit();
+    return null;
+  });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "jest"
+    "test": "jest",
+    "seed:services": "ts-node scripts/seedServiceTemplates.ts"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.5",

--- a/scripts/seedServiceTemplates.ts
+++ b/scripts/seedServiceTemplates.ts
@@ -1,0 +1,61 @@
+import { initializeApp, applicationDefault } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+initializeApp({
+  credential: applicationDefault(),
+  projectId: 'auditory-x-open-network',
+});
+
+const db = getFirestore();
+
+// Default templates grouped by creator role
+const templates: Record<string, Array<Record<string, any>>> = {
+  artist: [
+    {
+      id: 'feature-verse',
+      title: 'Feature Verse',
+      description: 'Add a guest verse to a track',
+      price: 100,
+    },
+    {
+      id: 'mix-master',
+      title: 'Mix & Master',
+      description: 'Professional mixing and mastering',
+      price: 200,
+    },
+  ],
+  videographer: [
+    {
+      id: 'music-video',
+      title: 'Music Video Shoot',
+      description: 'Full production for a music video',
+      price: 500,
+    },
+  ],
+  studio: [
+    {
+      id: 'hourly-session',
+      title: 'Studio Session',
+      description: 'Hourly recording session',
+      price: 50,
+    },
+  ],
+};
+
+async function seed() {
+  for (const [role, list] of Object.entries(templates)) {
+    for (const tpl of list) {
+      await db
+        .collection('serviceTemplates')
+        .doc(role)
+        .collection('templates')
+        .doc(tpl.id)
+        .set(tpl);
+    }
+  }
+  console.log('✅ Seeded service templates');
+}
+
+seed().catch((err) => {
+  console.error('❌ Failed to seed templates:', err);
+});


### PR DESCRIPTION
## Summary
- add script to seed Firestore service templates
- seed default service templates on user creation
- export new trigger from functions index
- add pnpm script for seeding templates

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845441492e48328a2cb2505bc866919