### PR TITLE
Add available-now filter for creators

### DIFF
--- a/__tests__/queryCreatorsAvailableNow.test.ts
+++ b/__tests__/queryCreatorsAvailableNow.test.ts
@@ -1,0 +1,79 @@
+import { queryCreators } from '@/lib/firestore/queryCreators';
+import {
+  collection,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit,
+  startAfter,
+  doc,
+  getDoc,
+} from 'firebase/firestore';
+
+jest.mock('@/lib/firebase', () => ({ db: {} }));
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+  limit: jest.fn(),
+  startAfter: jest.fn(),
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+}));
+
+const mockedCollection = collection as jest.MockedFunction<typeof collection>;
+const mockedGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
+const mockedQuery = query as jest.MockedFunction<typeof query>;
+const mockedWhere = where as jest.MockedFunction<typeof where>;
+const mockedOrderBy = orderBy as jest.MockedFunction<typeof orderBy>;
+const mockedLimit = limit as jest.MockedFunction<typeof limit>;
+const mockedDoc = doc as jest.MockedFunction<typeof doc>;
+const mockedGetDoc = getDoc as jest.MockedFunction<typeof getDoc>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedCollection.mockReturnValue('users' as any);
+  mockedQuery.mockReturnValue('q' as any);
+  mockedWhere.mockReturnValue('where' as any);
+  mockedOrderBy.mockReturnValue('order' as any);
+  mockedLimit.mockReturnValue('lim' as any);
+  mockedDoc.mockReturnValue('docRef' as any);
+  mockedGetDoc.mockResolvedValue({ exists: () => true } as any);
+});
+
+test('availableNow filters by timestamp', async () => {
+  const now = Date.now();
+  jest.spyOn(Date, 'now').mockReturnValue(now);
+  mockedGetDocs.mockResolvedValue({
+    docs: [
+      {
+        id: '1',
+        data: () => ({
+          name: 'A',
+          bio: 'b',
+          media: ['m'],
+          services: ['s'],
+          timezone: 'UTC',
+          nextAvailableTs: now + 3600 * 1000,
+        }),
+      },
+      {
+        id: '2',
+        data: () => ({
+          name: 'B',
+          bio: 'b',
+          media: ['m'],
+          services: ['s'],
+          timezone: 'UTC',
+          nextAvailableTs: now + 8 * 24 * 3600 * 1000,
+        }),
+      },
+    ],
+  } as any);
+
+  const { results } = await queryCreators({ availableNow: true });
+  expect(results.map((r) => r.uid)).toEqual(['1']);
+});

--- a/lib/firestore/updateAvailability.ts
+++ b/lib/firestore/updateAvailability.ts
@@ -1,7 +1,19 @@
 import { doc, updateDoc } from 'firebase/firestore';
 import { firestore } from '@lib/firebase/init';
+import { getNextDateForWeekday } from '@lib/google/utils';
 
 export const updateAvailability = async (providerId: string, availability: string[]) => {
   const providerRef = doc(firestore, 'users', providerId);
-  await updateDoc(providerRef, { availability });
+  const now = Date.now();
+  const nextTs = (() => {
+    const times = availability
+      .map((s) => {
+        const [day, time] = s.split(' ');
+        return new Date(`${getNextDateForWeekday(day)}T${time}:00`).getTime();
+      })
+      .filter((t) => t > now);
+    return times.length ? Math.min(...times) : null;
+  })();
+
+  await updateDoc(providerRef, { availability, nextAvailableTs: nextTs });
 };

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -34,6 +34,7 @@ export async function GET(req: Request) {
     service: searchParams.get('service') || undefined,
     proTier: searchParams.get('proTier') || undefined,
     verifiedOnly: searchParams.get('verifiedOnly') === 'true',
+    availableNow: searchParams.get('availableNow') === '1',
     lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : undefined,
     lng: searchParams.get('lng') ? parseFloat(searchParams.get('lng')!) : undefined,
     radiusKm: searchParams.get('radiusKm') ? parseInt(searchParams.get('radiusKm')!, 10) : undefined,

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -26,6 +26,7 @@ export default function ExplorePage() {
     location: searchParams.get('location') || '',
     service: searchParams.get('service') || '',
     proTier: searchParams.get('proTier') || '',
+    availableNow: searchParams.get('availableNow') === '1',
     searchNearMe: searchParams.get('searchNearMe') === 'true',
     lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : undefined,
     lng: searchParams.get('lng') ? parseFloat(searchParams.get('lng')!) : undefined,
@@ -42,6 +43,7 @@ export default function ExplorePage() {
     if (filters.searchNearMe) {
       query.set('searchNearMe', 'true');
     }
+    if (filters.availableNow) query.set('availableNow', '1');
     if (filters.lat) query.set('lat', String(filters.lat));
     if (filters.lng) query.set('lng', String(filters.lng));
     if (filters.radiusKm) query.set('radiusKm', String(filters.radiusKm));

--- a/src/components/explore/DiscoveryGrid.tsx
+++ b/src/components/explore/DiscoveryGrid.tsx
@@ -23,6 +23,7 @@ export default function DiscoveryGrid({ filters }: { filters: any }) {
     queryKey: ['creators', filters],
     queryFn: async ({ pageParam }) => {
       const params = new URLSearchParams({ limit: '20', ...filters });
+      if (filters.availableNow) params.set('availableNow', '1');
       if (pageParam) params.append('cursor', pageParam as string);
       track('search', { ...filters, page: pageParam ?? 1 });
       const res = await fetch(`/api/search?${params.toString()}`);

--- a/src/components/explore/FilterPanel.tsx
+++ b/src/components/explore/FilterPanel.tsx
@@ -11,6 +11,7 @@ type Props = {
     location: string;
     service: string;
     proTier?: 'standard' | 'verified' | 'signature';
+    availableNow?: boolean;
     searchNearMe?: boolean;
     lat?: number;
     lng?: number;
@@ -151,6 +152,21 @@ export default function FilterPanel({ filters, setFilters }: Props) {
             aria-label={Translate.txt('filterPanel.searchNearMe')}
           />
           <Translate t="filterPanel.searchNearMe" />
+        </label>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={!!filters.availableNow}
+            onChange={() => {
+              const next = !filters.availableNow;
+              track('filter_available_now', { on: next });
+              updateFilters({ ...filters, availableNow: next });
+            }}
+            className="accent-green-400"
+            aria-label={Translate.txt('filterPanel.availableNow')}
+          />
+          <Translate t="filterPanel.availableNow" />
         </label>
 
         {/* Tier toggles */}

--- a/src/components/explore/NewExploreGrid.tsx
+++ b/src/components/explore/NewExploreGrid.tsx
@@ -22,6 +22,7 @@ export default function NewExploreGrid({ filters }: { filters: any }) {
     queryKey: ['creators-new', filters],
     queryFn: async ({ pageParam }) => {
       const params = new URLSearchParams({ limit: '20', ...filters });
+      if (filters.availableNow) params.set('availableNow', '1');
       if (pageParam) params.append('cursor', pageParam as string);
       const res = await fetch(`/api/search?${params.toString()}`);
       const json = await res.json();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -32,6 +32,7 @@
   ,"filterPanel.sort.distance": "Sort by Distance"
   ,"filterPanel.sort.popularity": "Sort by Popularity"
   ,"filterPanel.searchNearMe": "Search Near Me"
+  ,"filterPanel.availableNow": "Available Soon"
   ,"filterPanel.signature": "Signature"
   ,"filterPanel.verified": "Verified"
   ,"savedFilters.savedPresets": "Saved Presets"

--- a/src/i18n/jp.json
+++ b/src/i18n/jp.json
@@ -32,6 +32,7 @@
   ,"filterPanel.sort.distance": "\u8ddd\u96e2\u9806"
   ,"filterPanel.sort.popularity": "\u4eba\u6c17\u9806"
   ,"filterPanel.searchNearMe": "\u8fd1\u304f\u3092\u691c\u7d22"
+  ,"filterPanel.availableNow": "72\u6642\u9593\u4ee5\u5185\u7a7a\u304d"
   ,"filterPanel.signature": "\u30b7\u30b0\u30cd\u30c1\u30e3"
   ,"filterPanel.verified": "\u8a3c\u660e\u6e08\u307f"
   ,"savedFilters.savedPresets": "\u4fdd\u5b58\u3055\u308c\u305f\u30d7\u30ea\u30bb\u30c3\u30c8"

--- a/src/i18n/kr.json
+++ b/src/i18n/kr.json
@@ -32,6 +32,7 @@
   ,"filterPanel.sort.distance": "\uac70\ub9ac \uc21c"
   ,"filterPanel.sort.popularity": "\uc778\uae30 \uc21c"
   ,"filterPanel.searchNearMe": "\uc804\uccb4 \uac80\uc0c9"
+  ,"filterPanel.availableNow": "72\uc2dc\uac04 \uc548 \uc0ac\uc6a9 \uac00\ub2a5"
   ,"filterPanel.signature": "\uc2dc\uadf8\ub2c8\ucc28"
   ,"filterPanel.verified": "\uc778\uc99d\ub41c"
   ,"savedFilters.savedPresets": "\uc800\uc7a5\ub41c \ud504\ub9ac\uc138\ud2b8"

--- a/src/lib/firestore/queryCreators.ts
+++ b/src/lib/firestore/queryCreators.ts
@@ -21,6 +21,7 @@ export async function queryCreators(filters: {
   location?: string;
   service?: string;
   proTier?: 'standard' | 'verified' | 'signature';
+  availableNow?: boolean;
   lat?: number;
   lng?: number;
   radiusKm?: number;
@@ -52,6 +53,16 @@ export async function queryCreators(filters: {
     qConstraints.push(where('proTier', '==', filters.proTier));
   }
 
+  if (filters.availableNow) {
+    qConstraints.push(
+      where(
+        'nextAvailableTs',
+        '<=',
+        Date.now() + 72 * 60 * 60 * 1000,
+      ),
+    );
+  }
+
   const base = query(
     collection(db, 'users'),
     ...qConstraints,
@@ -72,6 +83,15 @@ export async function queryCreators(filters: {
   let results = snapshot.docs
     .map((doc) => ({ uid: doc.id, ...doc.data() } as UserProfile))
     .filter(isProfileComplete);
+
+  if (filters.availableNow) {
+    const cutoff = Date.now() + 72 * 60 * 60 * 1000;
+    results = results.filter(
+      (c) =>
+        typeof (c as any).nextAvailableTs === 'number' &&
+        (c as any).nextAvailableTs <= cutoff,
+    );
+  }
 
   if (filters.lat && filters.lng) {
     const radius = filters.radiusKm ?? 50;


### PR DESCRIPTION
## Summary
- filter creators by soonest availability
- track toggle state
- update availability utilities to save nextAvailableTs
- expose availableNow search parameter
- adjust Explore filters to store this in URL
- test that creators with far future slots are excluded

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845462f8a908328b0a33b8dd8d8bfca