### PR TITLE
Implement monthly city role leaderboards

### DIFF
--- a/__tests__/leaderboard.test.ts
+++ b/__tests__/leaderboard.test.ts
@@ -1,6 +1,18 @@
 import { generateLeaderboard } from '@/lib/leaderboards'
 import { collection, query, orderBy, limit, getDocs, setDoc, doc, serverTimestamp } from 'firebase/firestore'
 
+jest.mock(
+  'firebase-functions',
+  () => ({ pubsub: { schedule: () => ({ onRun: () => jest.fn() }) } }),
+  { virtual: true }
+)
+jest.mock(
+  'firebase-admin',
+  () => ({ apps: [], initializeApp: jest.fn(), firestore: jest.fn(() => ({ batch: jest.fn(), collection: jest.fn() })) }),
+  { virtual: true }
+)
+import { buildLeaderboardData } from '../functions/src/cron/buildLeaderboards'
+
 jest.mock('@/lib/firebase', () => ({ db: {} }))
 
 jest.mock('firebase/firestore', () => ({
@@ -37,4 +49,16 @@ describe('leaderboard generation', () => {
     await generateLeaderboard('weekly', 1)
     expect(mockedSetDoc).toHaveBeenCalledWith('leaderDoc', expect.objectContaining({ entries: [{ uid: 'u1', points: 100 }] }))
   })
+})
+
+test('limits leaderboard size to 10', () => {
+  const users = Array.from({ length: 12 }).map((_, i) => ({
+    uid: 'u' + i,
+    city: 'tokyo',
+    role: 'producer',
+    pointsMonth: i,
+    displayName: 'U' + i,
+  }))
+  const map = buildLeaderboardData(users)
+  expect(map['tokyo']['producer']).toHaveLength(10)
 })

--- a/functions/src/cron/buildLeaderboards.ts
+++ b/functions/src/cron/buildLeaderboards.ts
@@ -1,0 +1,60 @@
+import * as functions from 'firebase-functions'
+import * as admin from 'firebase-admin'
+
+if (!admin.apps.length) {
+  admin.initializeApp()
+}
+
+export interface LeaderboardEntry {
+  uid: string
+  name?: string
+  points: number
+}
+
+export interface LeaderboardMap {
+  [city: string]: { [role: string]: LeaderboardEntry[] }
+}
+
+export function buildLeaderboardData(users: any[]): LeaderboardMap {
+  const map: LeaderboardMap = {}
+  users.forEach((u) => {
+    const { city, role, pointsMonth = 0, displayName } = u
+    if (!city || !role) return
+    if (!map[city]) map[city] = {}
+    if (!map[city][role]) map[city][role] = []
+    map[city][role].push({ uid: u.uid, name: displayName, points: pointsMonth })
+  })
+  Object.values(map).forEach((roles) => {
+    Object.keys(roles).forEach((r) => {
+      roles[r].sort((a, b) => b.points - a.points)
+      roles[r] = roles[r].slice(0, 10)
+    })
+  })
+  return map
+}
+
+export const buildLeaderboards = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(async () => {
+    const db = admin.firestore()
+    const snap = await db.collection('users').get()
+    const users = snap.docs.map((d) => ({ uid: d.id, ...d.data() }))
+    const grouped = buildLeaderboardData(users)
+    const batch = db.batch()
+
+    Object.entries(grouped).forEach(([city, roles]) => {
+      Object.entries(roles).forEach(([role, entries]) => {
+        const col = db.collection('leaderboards').doc(city).collection(role)
+        entries.forEach((entry) => {
+          batch.set(col.doc(entry.uid), entry)
+        })
+      })
+    })
+
+    if (new Date().getDate() === 1) {
+      snap.docs.forEach((d) => batch.update(d.ref, { pointsMonth: 0 }))
+    }
+
+    await batch.commit()
+    return null
+  })

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,2 +1,3 @@
 export * from './cron/streakReset';
+export * from './cron/buildLeaderboards';
 export * from './triggers/onProfileCreate';

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import DiscoveryGrid from '@/components/explore/DiscoveryGrid';
 import NewExploreGrid from '@/components/explore/NewExploreGrid';
 import FilterPanel from '@/components/explore/FilterPanel';
@@ -52,6 +53,11 @@ export default function ExplorePage() {
 
   return (
     <div className="min-h-screen bg-black text-white p-6">
+      <div className="text-right text-xs mb-2">
+        <Link href="/leaderboards/tokyo/producer" className="underline">
+          View Tokyo leaderboard
+        </Link>
+      </div>
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-3xl font-bold">Explore Creators</h1>
         <div className="flex gap-2">

--- a/src/app/leaderboards/[city]/[role]/page.tsx
+++ b/src/app/leaderboards/[city]/[role]/page.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { collection, getDocs, query, orderBy } from 'firebase/firestore'
+import { db } from '@/lib/firebase'
+import { PointsBadge } from '@/components/profile/PointsBadge'
+import { useParams } from 'next/navigation'
+
+interface Entry {
+  uid: string
+  name?: string
+  points: number
+}
+
+export default function LeaderboardCityRolePage() {
+  const params = useParams()
+  const city = Array.isArray(params.city) ? params.city[0] : params.city
+  const role = Array.isArray(params.role) ? params.role[0] : params.role
+  const [entries, setEntries] = useState<Entry[]>([])
+
+  useEffect(() => {
+    async function load() {
+      const col = collection(db, 'leaderboards', city as string, role as string)
+      const q = query(col, orderBy('points', 'desc'))
+      const snap = await getDocs(q)
+      setEntries(snap.docs.map(d => ({ uid: d.id, ...(d.data() as any) })) as Entry[])
+    }
+    if (city && role) load()
+  }, [city, role])
+
+  return (
+    <div className="min-h-screen bg-black text-white p-6">
+      <h1 className="text-3xl font-bold mb-4 capitalize">
+        {city} {role} Leaderboard
+      </h1>
+      <table className="min-w-full text-left text-sm">
+        <thead>
+          <tr>
+            <th className="py-2 pr-4">#</th>
+            <th className="py-2 pr-4">Name</th>
+            <th className="py-2 pr-4">XP</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((e, i) => (
+            <tr key={e.uid} className="border-t border-neutral-700">
+              <td className="py-1 pr-4">{i + 1}</td>
+              <td className="py-1 pr-4">{e.name || e.uid}</td>
+              <td className="py-1 pr-4">
+                <PointsBadge points={e.points} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- nightly cron to build city/role leaderboards and reset monthly XP
- export cron function from Firebase index
- leaderboard page for each city/role
- link from Explore page to Tokyo leaderboard
- unit test ensuring max 10 leaderboard entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684547e074748328a3962e4213e2bff2