### PR TITLE
Add revision tracking for bookings

### DIFF
--- a/lib/firestore/__tests__/createBooking.test.ts
+++ b/lib/firestore/__tests__/createBooking.test.ts
@@ -34,6 +34,7 @@ describe('createBooking', () => {
       status: 'pending',
       createdAt: 'ts',
       paid: false,
+      revisionsRemaining: 2,
     }))
     expect(id).toBe('abc123')
   })

--- a/lib/firestore/__tests__/requestRevision.test.ts
+++ b/lib/firestore/__tests__/requestRevision.test.ts
@@ -1,0 +1,36 @@
+import { requestRevision } from '@/lib/firestore/bookings/requestRevision';
+
+const get = jest.fn();
+const update = jest.fn();
+
+jest.mock('firebase-admin/app', () => ({
+  initializeApp: jest.fn(),
+  getApps: () => [],
+  getApp: jest.fn(),
+  cert: jest.fn(),
+}));
+
+jest.mock('firebase-admin/firestore', () => {
+  const doc = jest.fn(() => ({ get, update }));
+  return {
+    getFirestore: jest.fn(() => ({ collection: () => ({ doc }) })),
+    FieldValue: { increment: jest.fn(() => 'inc'), serverTimestamp: jest.fn(() => 'ts') },
+  };
+});
+
+jest.mock('@/lib/firestore/logging/logActivity', () => ({ logActivity: jest.fn() }));
+
+describe('requestRevision', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('second call when counter = 0 returns error', async () => {
+    get.mockResolvedValueOnce({ data: () => ({ revisionsRemaining: 1 }) });
+    await requestRevision({ bookingId: 'b1', userId: 'u1' });
+
+    get.mockResolvedValueOnce({ data: () => ({ revisionsRemaining: 0 }) });
+    const res = await requestRevision({ bookingId: 'b1', userId: 'u1' });
+    expect(res).toEqual({ error: 'No revisions remaining' });
+  });
+});

--- a/lib/firestore/createBooking.ts
+++ b/lib/firestore/createBooking.ts
@@ -13,6 +13,7 @@ export const createBooking = async (bookingData: {
     status: 'pending',
     createdAt: serverTimestamp(),
     paid: false,
+    revisionsRemaining: 2,
   });
   return docRef.id;
 };

--- a/src/app/api/bookings/request-revision/route.ts
+++ b/src/app/api/bookings/request-revision/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import withAuth from '@/app/api/_utils/withAuth';
+import { requestRevision } from '@/lib/firestore/bookings/requestRevision';
+
+async function handler(req: NextRequest & { user: any }) {
+  const body = await req.json();
+  const result = await requestRevision({
+    bookingId: body.bookingId,
+    userId: req.user.id || req.user.uid,
+  });
+
+  if ('error' in result) {
+    const status = result.error === 'No revisions remaining' ? 400 : 400;
+    return NextResponse.json({ error: result.error }, { status });
+  }
+
+  return NextResponse.json(result);
+}
+
+export const POST = withAuth(handler);
+export { handler }; // for testing

--- a/src/app/dashboard/bookings/[bookingId]/page.tsx
+++ b/src/app/dashboard/bookings/[bookingId]/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { getDoc, doc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import BookingChat from '@/components/booking/BookingChat';
+import BookingChatTopBar from '@/components/booking/BookingChatTopBar';
 import ContractViewer from '@/components/contract/ContractViewer';
 import ReleaseFundsButton from '@/components/booking/ReleaseFundsButton';
 import ReviewForm from '@/components/booking/ReviewForm';
@@ -83,6 +84,11 @@ export default function BookingDetailPage() {
               }}
             />
 
+            <BookingChatTopBar
+              bookingId={bookingId}
+              initialCount={booking.revisionsRemaining ?? 0}
+              isClient={isClient}
+            />
             <BookingChat bookingId={bookingId} />
 
             {typingUsers.length > 0 && (

--- a/src/components/booking/BookingChatTopBar.tsx
+++ b/src/components/booking/BookingChatTopBar.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '@/lib/hooks/useAuth';
+
+export default function BookingChatTopBar({
+  bookingId,
+  initialCount,
+  isClient,
+}: {
+  bookingId: string;
+  initialCount: number;
+  isClient: boolean;
+}) {
+  const { userData } = useAuth();
+  const [count, setCount] = useState(initialCount);
+  const [loading, setLoading] = useState(false);
+
+  const handleRequest = async () => {
+    if (loading || count <= 0) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/bookings/request-revision', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bookingId }),
+      });
+      if (res.ok) {
+        setCount(c => c - 1);
+      } else {
+        console.error('Revision request failed');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isEngineer = userData?.role === 'engineer';
+
+  return (
+    <div className="flex items-center justify-between mb-2">
+      {isEngineer && (
+        <span className="text-xs bg-neutral-700 text-white px-2 py-0.5 rounded">
+          Revisions left: {count}
+        </span>
+      )}
+      {isClient && count > 0 && (
+        <button
+          onClick={handleRequest}
+          disabled={loading}
+          className="btn btn-primary btn-sm"
+        >
+          {loading ? 'Requesting…' : 'Request Revision'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/firestore/bookings/requestRevision.ts
+++ b/src/lib/firestore/bookings/requestRevision.ts
@@ -1,0 +1,43 @@
+import { adminDb } from '@/lib/firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
+import { logActivity } from '@/lib/firestore/logging/logActivity';
+import { z } from 'zod';
+
+const schema = z.object({
+  bookingId: z.string().min(1),
+  userId: z.string().min(1),
+});
+
+export async function requestRevision(input: unknown) {
+  const parsed = schema.safeParse(input);
+  if (!parsed.success) {
+    console.error('❌ Invalid requestRevision input:', parsed.error.format());
+    return { error: 'Invalid input' } as const;
+  }
+
+  const { bookingId, userId } = parsed.data;
+
+  try {
+    const bookingRef = adminDb.collection('bookings').doc(bookingId);
+    const snap = await bookingRef.get();
+    const data = snap.data();
+    if (!data) throw new Error('Booking not found');
+
+    const current = data.revisionsRemaining ?? 0;
+    if (current <= 0) {
+      return { error: 'No revisions remaining' } as const;
+    }
+
+    await bookingRef.update({
+      revisionsRemaining: FieldValue.increment(-1),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+
+    await logActivity(userId, 'revision_requested', { bookingId });
+
+    return { success: true, revisionsRemaining: current - 1 } as const;
+  } catch (err: any) {
+    console.error('🔥 Failed to request revision:', err.message);
+    return { error: 'Failed to request revision' } as const;
+  }
+}


### PR DESCRIPTION
## Summary
- include `revisionsRemaining` when creating bookings
- show revision counter and client request button in chat
- add API endpoint to request a revision
- implement Firestore helper for revision requests
- test booking creation and revision logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684547d756d48328ba7f0bb23fbb933e