### PR TITLE
Add genre & BPM filters to explore

### DIFF
--- a/__tests__/queryCreatorsGenres.test.ts
+++ b/__tests__/queryCreatorsGenres.test.ts
@@ -1,0 +1,58 @@
+import { queryCreators } from '@/lib/firestore/queryCreators';
+import {
+  collection,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit as fsLimit,
+  doc,
+  getDoc,
+} from 'firebase/firestore';
+import { isProfileComplete } from '@/lib/profile/isProfileComplete';
+
+jest.mock('@/lib/firebase', () => ({ db: {} }));
+jest.mock('@/lib/profile/isProfileComplete', () => ({ isProfileComplete: jest.fn(() => true) }));
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  orderBy: jest.fn(),
+  startAfter: jest.fn(),
+  limit: jest.fn(),
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+}));
+
+const mockedCollection = collection as jest.MockedFunction<typeof collection>;
+const mockedGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
+const mockedQuery = query as jest.MockedFunction<typeof query>;
+const mockedWhere = where as jest.MockedFunction<typeof where>;
+const mockedOrderBy = orderBy as jest.MockedFunction<typeof orderBy>;
+const mockedLimit = fsLimit as jest.MockedFunction<typeof fsLimit>;
+const mockedGetDoc = (getDoc as any) as jest.MockedFunction<any>;
+const mockedDoc = (doc as any) as jest.MockedFunction<any>;
+
+describe('queryCreators genre filter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCollection.mockReturnValue('users' as any);
+    mockedQuery.mockReturnValue('q' as any);
+    mockedWhere.mockReturnValue('where' as any);
+    mockedOrderBy.mockReturnValue('order' as any);
+    mockedLimit.mockReturnValue('limit' as any);
+    mockedDoc.mockReturnValue('docRef' as any);
+    mockedGetDoc.mockResolvedValue({ exists: () => false });
+    mockedGetDocs.mockResolvedValue({
+      docs: [{ id: '1', data: () => ({ genres: ['Rock'] }) }],
+    } as any);
+  });
+
+  test('returns only matching genre docs', async () => {
+    const { results } = await queryCreators({ genres: ['Rock'] });
+    expect(mockedWhere).toHaveBeenCalledWith('genres', 'array-contains-any', ['Rock']);
+    expect(results).toHaveLength(1);
+    expect(results[0].uid).toBe('1');
+  });
+});

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -32,6 +32,15 @@ export async function GET(req: Request) {
     role: searchParams.get('role') || undefined,
     location: searchParams.get('location') || undefined,
     service: searchParams.get('service') || undefined,
+    genres: searchParams.get('genres')
+      ? searchParams.get('genres')!.split(',').filter(Boolean)
+      : undefined,
+    minBpm: searchParams.get('minBpm')
+      ? parseInt(searchParams.get('minBpm')!, 10)
+      : undefined,
+    maxBpm: searchParams.get('maxBpm')
+      ? parseInt(searchParams.get('maxBpm')!, 10)
+      : undefined,
     proTier: searchParams.get('proTier') || undefined,
     verifiedOnly: searchParams.get('verifiedOnly') === 'true',
     lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : undefined,

--- a/src/app/apply/[role]/page.tsx
+++ b/src/app/apply/[role]/page.tsx
@@ -31,6 +31,10 @@ export default function ApplyRolePage() {
   const [bio, setBio] = useState('');
   const [links, setLinks] = useState('');
   const [location, setLocation] = useState('');
+  const [genres, setGenres] = useState<string[]>([]);
+  const [genreInput, setGenreInput] = useState('');
+  const [minBpm, setMinBpm] = useState<number | undefined>(undefined);
+  const [maxBpm, setMaxBpm] = useState<number | undefined>(undefined);
   const [photo, setPhoto] = useState<File | null>(null);
   const [availabilitySlots, setAvailabilitySlots] = useState<string[]>([]);
   const [verified, setVerified] = useState(false);
@@ -46,6 +50,9 @@ export default function ApplyRolePage() {
         setBio(data.bio || '');
         setLinks(data.links || '');
         setLocation(data.location || '');
+        setGenres(data.genres || []);
+        setMinBpm(data.minBpm);
+        setMaxBpm(data.maxBpm);
         setAvailabilitySlots(data.availabilitySlots || []);
         setVerified(!!data.verified);
       } catch (e) {
@@ -60,11 +67,14 @@ export default function ApplyRolePage() {
       bio,
       links,
       location,
+      genres,
+      minBpm,
+      maxBpm,
       availabilitySlots,
       verified,
     };
     localStorage.setItem(`applyDraft-${role}`, JSON.stringify(data));
-  }, [stepIndex, bio, links, location, availabilitySlots, verified, role]);
+  }, [stepIndex, bio, links, location, genres, minBpm, maxBpm, availabilitySlots, verified, role]);
 
   const HOURS = ['10:00', '12:00', '14:00', '16:00', '18:00', '20:00'];
   const start = startOfWeek(new Date(), { weekStartsOn: 1 });
@@ -112,6 +122,9 @@ export default function ApplyRolePage() {
       role,
       bio,
       links,
+      genres,
+      minBpm,
+      maxBpm,
       location,
       photo: photo ? photo.name : null,
       availabilitySlots: slots,
@@ -149,6 +162,55 @@ export default function ApplyRolePage() {
             rows={5}
             className="w-full bg-neutral-800 border border-neutral-700 rounded px-3 py-2 text-sm text-white"
           />
+        </div>
+      </>
+    ),
+    music: (
+      <>
+        <div>
+          <label className="text-sm mb-1 block">Genres</label>
+          <div className="flex flex-wrap gap-1 mb-1">
+            {genres.map((g) => (
+              <span key={g} className="bg-neutral-700 text-xs px-2 py-0.5 rounded-full flex items-center gap-1">
+                {g}
+                <button type="button" onClick={() => setGenres(genres.filter(x => x !== g))}>×</button>
+              </span>
+            ))}
+          </div>
+          <input
+            type="text"
+            value={genreInput}
+            onChange={(e) => setGenreInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                const val = genreInput.trim();
+                if (val) setGenres([...genres, val]);
+                setGenreInput('');
+              }
+            }}
+            className="input-base"
+          />
+        </div>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="text-sm mb-1 block">Min BPM</label>
+            <input
+              type="number"
+              value={minBpm ?? ''}
+              onChange={(e) => setMinBpm(e.target.value ? +e.target.value : undefined)}
+              className="input-base"
+            />
+          </div>
+          <div className="flex-1">
+            <label className="text-sm mb-1 block">Max BPM</label>
+            <input
+              type="number"
+              value={maxBpm ?? ''}
+              onChange={(e) => setMaxBpm(e.target.value ? +e.target.value : undefined)}
+              className="input-base"
+            />
+          </div>
         </div>
       </>
     ),

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -37,6 +37,9 @@ export default function AdminDashboard() {
         name: submission.name,
         email: submission.email,
         role: submission.role,
+        genres: submission.genres || [],
+        minBpm: submission.minBpm || null,
+        maxBpm: submission.maxBpm || null,
         location: submission.location,
         bio: submission.bio,
         links: submission.links,
@@ -112,6 +115,16 @@ export default function AdminDashboard() {
               <p>
                 <strong>Bio:</strong> {s.bio}
               </p>
+              {s.genres && (
+                <p>
+                  <strong>Genres:</strong> {s.genres.join(', ')}
+                </p>
+              )}
+              {(s.minBpm || s.maxBpm) && (
+                <p>
+                  <strong>BPM:</strong> {s.minBpm ?? '?'} - {s.maxBpm ?? '?'}
+                </p>
+              )}
               <p>
                 <strong>Links:</strong> {s.links}
               </p>

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -25,6 +25,15 @@ export default function ExplorePage() {
     role: searchParams.get('role') || '',
     location: searchParams.get('location') || '',
     service: searchParams.get('service') || '',
+    genres: searchParams.get('genres')
+      ? searchParams.get('genres')!.split(',').filter(Boolean)
+      : [],
+    minBpm: searchParams.get('minBpm')
+      ? parseInt(searchParams.get('minBpm')!, 10)
+      : undefined,
+    maxBpm: searchParams.get('maxBpm')
+      ? parseInt(searchParams.get('maxBpm')!, 10)
+      : undefined,
     proTier: searchParams.get('proTier') || '',
     searchNearMe: searchParams.get('searchNearMe') === 'true',
     lat: searchParams.get('lat') ? parseFloat(searchParams.get('lat')!) : undefined,
@@ -38,6 +47,9 @@ export default function ExplorePage() {
     if (filters.role) query.set('role', filters.role);
     if (filters.location) query.set('location', filters.location);
     if (filters.service) query.set('service', filters.service);
+    if (filters.genres.length) query.set('genres', filters.genres.join(','));
+    if (filters.minBpm !== undefined) query.set('minBpm', String(filters.minBpm));
+    if (filters.maxBpm !== undefined) query.set('maxBpm', String(filters.maxBpm));
     if (filters.proTier) query.set('proTier', filters.proTier);
     if (filters.searchNearMe) {
       query.set('searchNearMe', 'true');

--- a/src/components/explore/DiscoveryGrid.tsx
+++ b/src/components/explore/DiscoveryGrid.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation';
 import { getProfileCompletion } from '@/lib/profile/getProfileCompletion';
 import { PointsBadge } from '@/components/profile/PointsBadge';
 import { Translate } from '@/i18n/Translate';
+import GenreBadges from '@/components/explore/GenreBadges';
 
 export default function DiscoveryGrid({ filters }: { filters: any }) {
   const {
@@ -88,6 +89,16 @@ export default function DiscoveryGrid({ filters }: { filters: any }) {
             {creator.bio || <Translate t="common.noBio" />}
           </p>
           <p className="text-xs text-blue-400 mb-1">📊 {creator.completion}% Profile Complete</p>
+          { (creator.role === 'artist' || creator.role === 'producer') && (
+            <>
+              <GenreBadges genres={(creator.genres || []).slice(0,3)} />
+              {creator.minBpm && creator.maxBpm && (
+                <span className="bg-neutral-700 text-xs px-2 py-0.5 rounded-full mr-1">
+                  {creator.minBpm}-{creator.maxBpm} BPM
+                </span>
+              )}
+            </>
+          ) }
           <PointsBadge points={creator.points} />
           <button
             className="border px-4 py-1 rounded text-sm"

--- a/src/components/explore/FilterPanel.tsx
+++ b/src/components/explore/FilterPanel.tsx
@@ -4,12 +4,16 @@ import LocationAutocomplete from './LocationAutocomplete';
 import SavedFilters from './SavedFilters';
 import { Translate } from '@/i18n/Translate';
 import { track } from '@/lib/analytics/track';
+import { useState } from 'react';
 
 type Props = {
   filters: {
     role: string;
     location: string;
     service: string;
+    genres: string[];
+    minBpm?: number;
+    maxBpm?: number;
     proTier?: 'standard' | 'verified' | 'signature';
     searchNearMe?: boolean;
     lat?: number;
@@ -53,6 +57,14 @@ export default function FilterPanel({ filters, setFilters }: Props) {
       ...filters,
       proTier: filters.proTier === tier ? undefined : tier,
     });
+  };
+
+  const [genreInput, setGenreInput] = useState('');
+  const addGenre = () => {
+    const val = genreInput.trim();
+    if (!val) return;
+    updateFilters({ ...filters, genres: [...filters.genres, val] });
+    setGenreInput('');
   };
 
   /* ——— UI ——— */
@@ -127,6 +139,76 @@ export default function FilterPanel({ filters, setFilters }: Props) {
           }
           className="input-base"
         />
+
+        {/* Genres multi-select */}
+        <div>
+          <label className="text-sm block mb-1">Genres</label>
+          <div className="flex flex-wrap gap-1 mb-1">
+            {filters.genres.map((g) => (
+              <span
+                key={g}
+                className="bg-neutral-700 text-xs px-2 py-0.5 rounded-full flex items-center gap-1"
+              >
+                {g}
+                <button
+                  type="button"
+                  onClick={() =>
+                    updateFilters({
+                      ...filters,
+                      genres: filters.genres.filter((x) => x !== g),
+                    })
+                  }
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+          <input
+            type="text"
+            value={genreInput}
+            onChange={(e) => setGenreInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addGenre();
+              }
+            }}
+            className="input-base"
+          />
+        </div>
+
+        {/* BPM range */}
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="text-sm block mb-1">Min BPM</label>
+            <input
+              type="number"
+              value={filters.minBpm ?? ''}
+              onChange={(e) =>
+                updateFilters({
+                  ...filters,
+                  minBpm: e.target.value ? +e.target.value : undefined,
+                })
+              }
+              className="input-base"
+            />
+          </div>
+          <div className="flex-1">
+            <label className="text-sm block mb-1">Max BPM</label>
+            <input
+              type="number"
+              value={filters.maxBpm ?? ''}
+              onChange={(e) =>
+                updateFilters({
+                  ...filters,
+                  maxBpm: e.target.value ? +e.target.value : undefined,
+                })
+              }
+              className="input-base"
+            />
+          </div>
+        </div>
 
         {/* Sort dropdown */}
         <select

--- a/src/components/explore/GenreBadges.tsx
+++ b/src/components/explore/GenreBadges.tsx
@@ -1,0 +1,16 @@
+'use client';
+export default function GenreBadges({ genres }: { genres: string[] }) {
+  if (!genres?.length) return null;
+  return (
+    <div className="flex flex-wrap gap-1 mb-1">
+      {genres.map(g => (
+        <span
+          key={g}
+          className="bg-neutral-700 text-xs px-2 py-0.5 rounded-full"
+        >
+          {g}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/components/explore/NewExploreGrid.tsx
+++ b/src/components/explore/NewExploreGrid.tsx
@@ -9,6 +9,7 @@ import { SaveButton } from '@/components/profile/SaveButton';
 import { getProfileCompletion } from '@/lib/profile/getProfileCompletion';
 import { PointsBadge } from '@/components/profile/PointsBadge';
 import { RoleBadge } from '@/components/explore/RoleBadge';
+import GenreBadges from '@/components/explore/GenreBadges';
 import { Translate } from '@/i18n/Translate';
 
 export default function NewExploreGrid({ filters }: { filters: any }) {
@@ -98,6 +99,18 @@ export default function NewExploreGrid({ filters }: { filters: any }) {
 
           {/* Role specific metric */}
           <RoleBadge role={c.role} profile={c} />
+
+          {/* Genres & BPM */}
+          {(c.role === 'artist' || c.role === 'producer') && (
+            <>
+              <GenreBadges genres={(c.genres || []).slice(0, 3)} />
+              {c.minBpm && c.maxBpm && (
+                <span className="bg-neutral-700 text-xs px-2 py-0.5 rounded-full mr-1">
+                  {c.minBpm}-{c.maxBpm} BPM
+                </span>
+              )}
+            </>
+          )}
 
           {/* XP / gamification badge */}
           <PointsBadge points={c.points} />

--- a/src/constants/onboardingByRole.ts
+++ b/src/constants/onboardingByRole.ts
@@ -16,6 +16,7 @@ export const onboardingByRole = {
   ],
   artist: [
     'basic',
+    'music',
     'audio',
     'pricing',
     'availability',
@@ -23,6 +24,7 @@ export const onboardingByRole = {
   ],
   producer: [
     'basic',
+    'music',
     'beats',
     'pricing',
     'availability',

--- a/src/lib/firestore/explore/queryCreators.ts
+++ b/src/lib/firestore/explore/queryCreators.ts
@@ -15,6 +15,9 @@ export const queryCreators = async (filters: {
   verifiedOnly: boolean;
   location?: string;
   service?: string;
+  genres?: string[];
+  minBpm?: number;
+  maxBpm?: number;
   lat?: number;
   lng?: number;
   radiusKm?: number;
@@ -38,6 +41,18 @@ export const queryCreators = async (filters: {
 
   if (filters.service) {
     constraints.push(where('services', 'array-contains', filters.service));
+  }
+
+  if (filters.genres && filters.genres.length > 0) {
+    constraints.push(where('genres', 'array-contains-any', filters.genres));
+  }
+
+  if (filters.minBpm !== undefined) {
+    constraints.push(where('maxBpm', '>=', filters.minBpm));
+  }
+
+  if (filters.maxBpm !== undefined) {
+    constraints.push(where('minBpm', '<=', filters.maxBpm));
   }
 
   if (filters.sortKey) {

--- a/src/lib/firestore/queryCreators.ts
+++ b/src/lib/firestore/queryCreators.ts
@@ -20,6 +20,9 @@ export async function queryCreators(filters: {
   verifiedOnly?: boolean;
   location?: string;
   service?: string;
+  genres?: string[];
+  minBpm?: number;
+  maxBpm?: number;
   proTier?: 'standard' | 'verified' | 'signature';
   lat?: number;
   lng?: number;
@@ -46,6 +49,18 @@ export async function queryCreators(filters: {
     qConstraints.push(
       where('services', 'array-contains', filters.service.toLowerCase())
     );
+  }
+
+  if (filters.genres && filters.genres.length > 0) {
+    qConstraints.push(where('genres', 'array-contains-any', filters.genres));
+  }
+
+  if (filters.minBpm !== undefined) {
+    qConstraints.push(where('maxBpm', '>=', filters.minBpm));
+  }
+
+  if (filters.maxBpm !== undefined) {
+    qConstraints.push(where('minBpm', '<=', filters.maxBpm));
   }
 
   if (filters.proTier) {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -6,6 +6,9 @@ export interface UserProfile {
   tags: string[];
   media: string[];
   availability: string[];
+  genres?: string[];
+  minBpm?: number;
+  maxBpm?: number;
   socials: {
     instagram?: string;
     twitter?: string;


### PR DESCRIPTION
## Summary
- collect genres and BPM range during onboarding
- filter creators by genres and BPM range in Explore
- display genre badges and BPM pill on Explore cards
- support new fields in admin approval flow
- test genre filtering in `queryCreators`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684547c0b72483289dc4493d07b2ddd2