### PR TITLE
Implement studio quote calculator

### DIFF
--- a/__tests__/quoteCalculator.test.ts
+++ b/__tests__/quoteCalculator.test.ts
@@ -1,0 +1,7 @@
+import { calcQuote } from '@/components/booking/studio/calcQuote'
+import type { Room } from '@/types/user'
+
+test('calculates quote with engineer correctly', () => {
+  const room: Room = { name: 'A', hourlyRate: 60, minBlock: 1, hasEngineer: true, engineerFee: 30 }
+  expect(calcQuote(room, 3, true)).toBe(210)
+})

--- a/lib/firestore/__tests__/createBooking.test.ts
+++ b/lib/firestore/__tests__/createBooking.test.ts
@@ -25,7 +25,7 @@ describe('createBooking', () => {
     mockedCollection.mockReturnValue(collRef as any)
     mockedAddDoc.mockResolvedValue({ id: 'abc123' } as any)
 
-    const booking = { clientId: 'c1', providerId: 'p1', service: 's1', dateTime: 'now', message: 'msg' }
+    const booking = { clientId: 'c1', providerId: 'p1', service: 's1', dateTime: 'now', message: 'msg', quote: 210 }
     const id = await createBooking(booking)
 
     expect(mockedCollection).toHaveBeenCalledWith(firestore, 'bookings')

--- a/lib/firestore/createBooking.ts
+++ b/lib/firestore/createBooking.ts
@@ -6,7 +6,8 @@ export const createBooking = async (bookingData: {
   providerId: string,
   service: string,
   dateTime: string,
-  message?: string
+  message?: string,
+  quote?: number
 }) => {
   const docRef = await addDoc(collection(firestore, 'bookings'), {
     ...bookingData,

--- a/pages/api/stripe/create-checkout-session.ts
+++ b/pages/api/stripe/create-checkout-session.ts
@@ -6,8 +6,9 @@ import { z } from 'zod';
 
 const schema = z.object({
   bookingId: z.string().min(1),
-  price: z.number().positive(),
+  amount: z.number().positive(),
   buyerEmail: z.string().email(),
+  metadata: z.record(z.any()).optional(),
 });
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -25,10 +26,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'Invalid input' });
   }
 
-  const { bookingId, price, buyerEmail } = result.data;
+  const { bookingId, amount, buyerEmail, metadata } = result.data;
 
   try {
-    const url = await createCheckoutSession({ bookingId, price, buyerEmail });
+    const url = await createCheckoutSession({ bookingId, amount, buyerEmail, metadata });
     return res.status(200).json({ url });
   } catch (err) {
     console.error('❌ Stripe session failed:', err);

--- a/src/app/api/book/route.ts
+++ b/src/app/api/book/route.ts
@@ -19,6 +19,7 @@ const BookingSchema = z.object({
   date: z.string().min(1),
   time: z.string().min(1),
   message: z.string().min(1),
+  quote: z.number().positive().optional(),
 });
 
 export async function POST(req: NextRequest) {
@@ -36,7 +37,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { serviceId, date, time, message } = parsed.data;
+  const { serviceId, date, time, message, quote } = parsed.data;
 
   try {
     const q = query(
@@ -58,6 +59,7 @@ export async function POST(req: NextRequest) {
       date,
       time,
       message,
+      quote,
       userId: session.user.id,
       status: 'pending',
       createdAt: serverTimestamp(),
@@ -68,6 +70,7 @@ export async function POST(req: NextRequest) {
       date,
       time,
       message,
+      quote,
       requestId: docRef.id,
     });
 

--- a/src/app/api/create-checkout-session/route.ts
+++ b/src/app/api/create-checkout-session/route.ts
@@ -9,7 +9,7 @@ import { logger } from '@lib/logger';
 
 const CheckoutSchema = z.object({
   bookingId: z.string().min(1),
-  price: z.number().positive(),
+  amount: z.number().positive(),
   buyerEmail: z.string().email(),
   providerId: z.string().min(1),
 });
@@ -26,16 +26,16 @@ async function handler(req: NextRequest & { user: any }) {
       );
     }
 
-    const { bookingId, price, buyerEmail, providerId } = parsed.data;
+    const { bookingId, amount, buyerEmail, providerId } = parsed.data;
 
-    const { url } = await createCheckoutSession({ bookingId, price, buyerEmail });
+    const { url } = await createCheckoutSession({ bookingId, amount, buyerEmail, metadata: { providerId } });
 
     const ip = req.headers.get('x-forwarded-for') || req.ip || 'unknown';
     const userAgent = req.headers.get('user-agent') || 'unknown';
 
     await logActivity(req.user.uid || req.user.email, 'checkout_initiated', {
       bookingId,
-      price,
+      amount,
       providerId,
     }, {
       ip,

--- a/src/app/api/payments/create-checkout-session/route.ts
+++ b/src/app/api/payments/create-checkout-session/route.ts
@@ -9,7 +9,7 @@ import { logger } from '@lib/logger';
 
 const CheckoutSchema = z.object({
   bookingId: z.string().min(1),
-  price: z.number().positive(),
+  amount: z.number().positive(),
   buyerEmail: z.string().email(),
   providerId: z.string().min(1),
 });
@@ -28,16 +28,16 @@ async function handler(req: NextRequest) {
       );
     }
 
-    const { bookingId, price, buyerEmail, providerId } = parsed.data;
+    const { bookingId, amount, buyerEmail, providerId } = parsed.data;
 
-    const { url } = await createCheckoutSession({ bookingId, price, buyerEmail });
+    const { url } = await createCheckoutSession({ bookingId, amount, buyerEmail, metadata: { providerId } });
 
     const ip = req.headers.get('x-forwarded-for') || req.ip || 'unknown';
     const userAgent = req.headers.get('user-agent') || 'unknown';
 
     await logActivity(user.uid || user.email, 'checkout_initiated', {
       bookingId,
-      price,
+      amount,
       providerId,
     }, {
       ip,

--- a/src/components/booking/studio/QuoteCalculator.tsx
+++ b/src/components/booking/studio/QuoteCalculator.tsx
@@ -1,0 +1,73 @@
+'use client';
+import { useEffect, useState } from 'react';
+import type { Room } from '@/types/user';
+import { calcQuote } from './calcQuote';
+
+interface Props {
+  rooms: Room[];
+  onChange?: (amount: number) => void;
+}
+
+export default function QuoteCalculator({ rooms, onChange }: Props) {
+  const [roomIndex, setRoomIndex] = useState(0);
+  const [hours, setHours] = useState(rooms[0]?.minBlock || 1);
+  const [withEngineer, setWithEngineer] = useState(false);
+
+  const room = rooms[roomIndex] || rooms[0];
+
+  useEffect(() => {
+    if (!room) return;
+    setHours(room.minBlock);
+    setWithEngineer(false);
+  }, [roomIndex]);
+
+  const quote = room ? calcQuote(room, hours, withEngineer) : 0;
+
+  useEffect(() => {
+    onChange && onChange(quote);
+  }, [quote, onChange]);
+
+  if (!room) return null;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="text-sm font-medium block mb-1">Room</label>
+        <select
+          className="input-base"
+          value={roomIndex}
+          onChange={(e) => setRoomIndex(Number(e.target.value))}
+        >
+          {rooms.map((r, i) => (
+            <option key={i} value={i}>
+              {r.name} (${r.hourlyRate}/hr)
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="text-sm font-medium block mb-1">Hours</label>
+        <input
+          type="number"
+          className="input-base"
+          step={room.minBlock}
+          min={room.minBlock}
+          value={hours}
+          onChange={(e) => setHours(Number(e.target.value))}
+        />
+      </div>
+      {room.hasEngineer && (
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="w-4 h-4"
+            checked={withEngineer}
+            onChange={(e) => setWithEngineer(e.target.checked)}
+          />
+          Add engineer (+${room.engineerFee})
+        </label>
+      )}
+      <p className="font-semibold">Total: ${quote}</p>
+    </div>
+  );
+}

--- a/src/components/booking/studio/StudioBookingForm.tsx
+++ b/src/components/booking/studio/StudioBookingForm.tsx
@@ -1,0 +1,109 @@
+'use client';
+import { useState } from 'react';
+import { useAuth } from '@/lib/hooks/useAuth';
+import toast from 'react-hot-toast';
+import WeeklyCalendarSelector from '../WeeklyCalendarSelector';
+import QuoteCalculator from './QuoteCalculator';
+import { createBooking } from '@lib/firestore/createBooking';
+import { checkBookingConflict } from '@/lib/firestore/checkBookingConflict';
+import { useProviderAvailability } from '@/lib/hooks/useProviderAvailability';
+import { getNextDateForWeekday } from '@/lib/google/utils';
+import type { Room } from '@/types/user';
+
+interface Props {
+  providerId: string;
+  rooms: Room[];
+  onBooked?: () => void;
+}
+
+export default function StudioBookingForm({ providerId, rooms, onBooked }: Props) {
+  const { user } = useAuth();
+  const { slots, busySlots, timezone } = useProviderAvailability(providerId);
+  const [selectedTime, setSelectedTime] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+  const [quote, setQuote] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  if (!user) {
+    return (
+      <div className="p-4 border rounded bg-white text-black space-y-2">
+        <p>Please log in to request a booking.</p>
+        <a href="/login" className="btn btn-primary">Login</a>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = message.trim();
+
+    if (!selectedTime) {
+      toast.error('Please select a time slot.');
+      return;
+    }
+
+    if (loading) return;
+
+    setLoading(true);
+    try {
+      const conflict = await checkBookingConflict(providerId, selectedTime);
+      if (conflict) {
+        toast.error('Time slot already booked');
+        setLoading(false);
+        return;
+      }
+      await createBooking({
+        clientId: user.uid,
+        providerId,
+        service: 'studio',
+        dateTime: selectedTime,
+        message: trimmed,
+        quote,
+      });
+      toast.success('Booking request sent!');
+      setMessage('');
+      setSelectedTime(null);
+      onBooked && onBooked();
+    } catch (err) {
+      console.error('Booking submission failed:', err);
+      toast.error('Failed to send booking request.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4 border rounded bg-white text-black">
+      <QuoteCalculator rooms={rooms} onChange={setQuote} />
+      <WeeklyCalendarSelector
+        availability={slots
+          .map((s) => `${getNextDateForWeekday(s.day as any)}T${s.time}`)
+          .filter(
+            (dt) => !busySlots.some((b) => `${getNextDateForWeekday(b.day as any)}T${b.time}` === dt)
+          )}
+        onSelect={(dt) => setSelectedTime(dt as string)}
+      />
+      <p className="text-xs text-gray-600">Provider timezone: {timezone || 'N/A'}</p>
+      <label htmlFor="booking-message" className="text-sm font-medium">Message to provider</label>
+      <textarea
+        id="booking-message"
+        aria-label="Booking message"
+        placeholder="Type your message..."
+        value={message}
+        onChange={(e) => setMessage(e.target.value.replace(/\s{2,}/g, ' '))}
+        className="textarea-base"
+        maxLength={500}
+        disabled={loading}
+      />
+      <div className="text-xs text-right text-gray-500">{message.length}/500</div>
+      <button
+        type="submit"
+        aria-label="Send booking request"
+        disabled={loading || !message.trim() || !selectedTime}
+        className="btn btn-primary"
+      >
+        {loading ? 'Sending…' : `Send Booking Request ($${quote})`}
+      </button>
+    </form>
+  );
+}

--- a/src/components/booking/studio/calcQuote.ts
+++ b/src/components/booking/studio/calcQuote.ts
@@ -1,0 +1,5 @@
+import type { Room } from '@/types/user'
+
+export function calcQuote(room: Room, hours: number, withEngineer: boolean) {
+  return room.hourlyRate * hours + (withEngineer ? room.engineerFee : 0)
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -24,6 +24,16 @@ export interface UserProfile {
    * Community contribution points. Starts at 0.
    */
   points?: number;
+  /** Rooms for studio profiles */
+  rooms?: Room[];
+}
+
+export interface Room {
+  name: string;
+  hourlyRate: number;
+  minBlock: number;
+  hasEngineer: boolean;
+  engineerFee: number;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- add `rooms` to user profile types
- allow bookings to store a quote amount
- create quote calculator and studio booking form
- include quote in `/api/book` and Stripe checkout session
- test quote calculation and bookings

## Testing
- `pnpm tsc --noEmit` *(fails: cannot find some modules)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684548e3e198832884ce99784108372f