### PR TITLE
Fix missing availability import

### DIFF
--- a/src/lib/availability/getNextAvailable.ts
+++ b/src/lib/availability/getNextAvailable.ts
@@ -1,0 +1,1 @@
+export * from '../firestore/getNextAvailable'


### PR DESCRIPTION
## Summary
- add availability/getNextAvailable alias that re-exports from firestore

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845cc1362e08328b14cabd4e88a9b2f