### PR TITLE
Update AGENTS instructions for TypeScript enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,19 @@ This repository contains a Next.js application with a Node.js backend and Fireba
   ```bash
   pnpm test gamification
   ```
+
+## ESLint Rules
+Add the following rule to enforce TypeScript file extensions:
+```json
+{
+  "rules": {
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "Program[sourceType='module'][filename=/\\.jsx?$/]",
+        "message": "All source files must be .ts or .tsx"
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
## Summary
- document ESLint rule that forbids `.js`/`.jsx` source files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d2a5a914832893fb2b2e8ae508be