### PR TITLE
Add mock creators and update seeding

### DIFF
--- a/data/profiles.json
+++ b/data/profiles.json
@@ -18,5 +18,65 @@
     "bio": "State-of-the-art recording studio in Shibuya.",
     "portfolio": "https://studiotokyo.com",
     "contact": "booking@studiotokyo.com"
+  },
+  {
+    "id": 3,
+    "name": "Lisa Beats",
+    "role": "Producer",
+    "location": "Chicago, USA",
+    "image": "https://source.unsplash.com/random/800x400?producer",
+    "bio": "Multi-platinum producer with a knack for trap drums.",
+    "portfolio": "https://lisabeats.example.com",
+    "contact": "contact@lisabeats.com"
+  },
+  {
+    "id": 4,
+    "name": "VisualMaster",
+    "role": "Videographer",
+    "location": "Berlin, Germany",
+    "image": "https://source.unsplash.com/random/800x400?videographer",
+    "bio": "Award-winning videographer capturing stories worldwide.",
+    "portfolio": "https://visualmaster.example.com",
+    "contact": "info@visualmaster.io"
+  },
+  {
+    "id": 5,
+    "name": "Mika Tanaka",
+    "role": "Artist",
+    "location": "Osaka, Japan",
+    "image": "https://source.unsplash.com/random/800x400?artist",
+    "bio": "Genre-bending singer blending J-pop with R&B.",
+    "portfolio": "https://mika.example.jp",
+    "contact": "booking@mika.jp"
+  },
+  {
+    "id": 6,
+    "name": "MixMag Studios",
+    "role": "Studio",
+    "location": "London, UK",
+    "image": "https://source.unsplash.com/random/800x400?studio",
+    "bio": "Boutique studio focused on analog warmth and vintage gear.",
+    "portfolio": "https://mixmagstudios.co.uk",
+    "contact": "hello@mixmagstudios.co.uk"
+  },
+  {
+    "id": 7,
+    "name": "Beat Lab",
+    "role": "Producer",
+    "location": "New York, USA",
+    "image": "https://source.unsplash.com/random/800x400?music",
+    "bio": "Underground producer known for experimental sounds.",
+    "portfolio": "https://beatlab.example.com",
+    "contact": "beatlab@music.com"
+  },
+  {
+    "id": 8,
+    "name": "FilmCraft",
+    "role": "Videographer",
+    "location": "Vancouver, Canada",
+    "image": "https://source.unsplash.com/random/800x400?film",
+    "bio": "Documentary specialist bringing stories to life.",
+    "portfolio": "https://filmcraft.ca",
+    "contact": "hello@filmcraft.ca"
   }
 ]

--- a/scripts/seedProfiles.mjs
+++ b/scripts/seedProfiles.mjs
@@ -1,30 +1,11 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore, setDoc, doc } from 'firebase/firestore';
 import { firebaseConfig } from '../app/firebase.js';
+import profiles from '../data/profiles.json' assert { type: 'json' };
 
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
-const profiles = [
-  {
-    id: 'artist123',
-    name: 'Jay Wavez',
-    role: 'Artist',
-    location: 'Tokyo, Japan',
-    bio: 'Independent hip-hop artist blending cultures.',
-    portfolio: 'https://jaywavez.com',
-    image: 'https://source.unsplash.com/random/800x400?artist'
-  },
-  {
-    id: 'studio001',
-    name: 'Skyline Studios',
-    role: 'Studio',
-    location: 'Shibuya, Tokyo',
-    bio: 'Premium recording studio for modern sound.',
-    portfolio: 'https://skyline-studios.jp',
-    image: 'https://source.unsplash.com/random/800x400?studio'
-  }
-];
 
 async function seed() {
   await Promise.all(


### PR DESCRIPTION
## Summary
- expand `data/profiles.json` with more sample creator profiles
- load that JSON into `scripts/seedProfiles.mjs` for Firestore seeding

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845f027997c8328b36384535129347f