### PR TITLE
Add missing unit tests

### DIFF
--- a/src/hooks/__tests__/useSidebarToggle.test.tsx
+++ b/src/hooks/__tests__/useSidebarToggle.test.tsx
@@ -1,0 +1,21 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { useSidebarToggle } from '../useSidebarToggle';
+
+test('toggle and close update state', () => {
+  const result: any = {};
+  function Test() {
+    Object.assign(result, useSidebarToggle());
+    return null;
+  }
+  const div = document.createElement('div');
+  const root = createRoot(div);
+  act(() => { root.render(<Test />); });
+  expect(result.open).toBe(false);
+  act(() => { result.toggle(); });
+  expect(result.open).toBe(true);
+  act(() => { result.close(); });
+  expect(result.open).toBe(false);
+});

--- a/src/lib/__tests__/fetchUsers.test.ts
+++ b/src/lib/__tests__/fetchUsers.test.ts
@@ -1,0 +1,25 @@
+import { fetchUsers } from '../fetchUsers';
+import { collection, getDocs } from 'firebase/firestore';
+
+jest.mock('../firebase', () => ({ db: {} }));
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(),
+  getDocs: jest.fn()
+}));
+
+const mockedCollection = collection as jest.MockedFunction<typeof collection>;
+const mockedGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedCollection.mockReturnValue('ref' as any);
+});
+
+test('fetches users and maps data', async () => {
+  mockedGetDocs.mockResolvedValue({
+    docs: [{ id: '1', data: () => ({ name: 'Jane' }) }]
+  } as any);
+  const users = await fetchUsers();
+  expect(mockedCollection).toHaveBeenCalledWith({}, 'users');
+  expect(users).toEqual([{ id: '1', name: 'Jane' }]);
+});

--- a/src/lib/analytics/__tests__/track.client.test.ts
+++ b/src/lib/analytics/__tests__/track.client.test.ts
@@ -1,0 +1,9 @@
+/** @jest-environment jsdom */
+import { track } from '../track';
+
+test('calls gtag when present', () => {
+  const gtag = jest.fn();
+  (window as any).gtag = gtag;
+  track('play', { id: 1 });
+  expect(gtag).toHaveBeenCalledWith('event', 'play', { id: 1 });
+});

--- a/src/lib/analytics/__tests__/track.node.test.ts
+++ b/src/lib/analytics/__tests__/track.node.test.ts
@@ -1,0 +1,6 @@
+/** @jest-environment node */
+import { track } from '../track';
+
+test('does not throw on server', () => {
+  expect(() => track('event')).not.toThrow();
+});

--- a/src/lib/email/__tests__/sendBookingConfirmation.test.ts
+++ b/src/lib/email/__tests__/sendBookingConfirmation.test.ts
@@ -1,0 +1,27 @@
+import { sendBookingConfirmation } from '../sendBookingConfirmation';
+import { sendEmail } from '../sendEmail';
+
+jest.mock('../sendEmail', () => ({ sendEmail: jest.fn() }));
+const mockedSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('calls sendEmail with formatted subject', async () => {
+  mockedSendEmail.mockResolvedValue({ success: true });
+  const res = await sendBookingConfirmation('to@test.com', 'Jan 1', 'msg', 'Joe');
+  expect(mockedSendEmail).toHaveBeenCalledWith(
+    'to@test.com',
+    '📅 New Booking Request – Jan 1',
+    'booking-confirmation.html',
+    { selectedTime: 'Jan 1', message: 'msg', senderName: 'Joe', providerTZ: '', clientTZ: '' }
+  );
+  expect(res).toEqual({ success: true });
+});
+
+test('returns error when sendEmail fails', async () => {
+  mockedSendEmail.mockResolvedValue({ error: 'e' } as any);
+  const res = await sendBookingConfirmation('to@test.com', 'Jan 1', 'msg');
+  expect(res).toEqual({ error: 'e' });
+});

--- a/src/lib/email/__tests__/sendDisputeEmail.test.ts
+++ b/src/lib/email/__tests__/sendDisputeEmail.test.ts
@@ -1,0 +1,27 @@
+import { sendDisputeEmail } from '../sendDisputeEmail';
+import { sendEmail } from '../sendEmail';
+
+jest.mock('../sendEmail', () => ({ sendEmail: jest.fn() }));
+const mockedSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('calls sendEmail with admin address', async () => {
+  mockedSendEmail.mockResolvedValue({ success: true });
+  const res = await sendDisputeEmail('b1', 'u1', 'bad');
+  expect(mockedSendEmail).toHaveBeenCalledWith(
+    'admin@auditoryx.com',
+    '🛑 New Dispute Submitted – Booking b1',
+    'dispute-notification.html',
+    { bookingId: 'b1', fromUser: 'u1', reason: 'bad' }
+  );
+  expect(res).toEqual({ success: true });
+});
+
+test('returns error when sendEmail fails', async () => {
+  mockedSendEmail.mockResolvedValue({ error: 'e' } as any);
+  const res = await sendDisputeEmail('b1', 'u1', 'bad');
+  expect(res).toEqual({ error: 'e' });
+});

--- a/src/lib/email/__tests__/sendEmail.test.ts
+++ b/src/lib/email/__tests__/sendEmail.test.ts
@@ -1,0 +1,39 @@
+import { sendEmail } from '../sendEmail';
+import nodemailer from 'nodemailer';
+import fs from 'fs';
+import path from 'path';
+
+jest.mock('nodemailer');
+jest.mock('fs');
+jest.mock('path');
+
+const sendMail = jest.fn();
+(nodemailer.createTransport as jest.Mock).mockReturnValue({ sendMail });
+(fs.readFileSync as jest.Mock).mockReturnValue('Hi {{name}}');
+(path.join as jest.Mock).mockReturnValue('/template.html');
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('sends email and returns success', async () => {
+  sendMail.mockResolvedValue({ messageId: '1' });
+  process.env.SMTP_EMAIL = 'from@test.com';
+  const res = await sendEmail('to@test.com', 'Sub', 'welcome.html', { name: 'A' });
+  expect(path.join).toHaveBeenCalled();
+  expect(fs.readFileSync).toHaveBeenCalledWith('/template.html', 'utf-8');
+  expect(sendMail).toHaveBeenCalledWith({
+    from: '"AuditoryX" <from@test.com>',
+    to: 'to@test.com',
+    subject: 'Sub',
+    html: 'Hi A',
+    text: 'Hi A'
+  });
+  expect(res).toEqual({ success: true });
+});
+
+test('returns error on failure', async () => {
+  sendMail.mockRejectedValue(new Error('fail'));
+  const res = await sendEmail('to@test.com', 'Sub', 't.html', {});
+  expect(res).toEqual({ error: 'Email send failed' });
+});

--- a/src/lib/firebase/__tests__/uploadMedia.test.ts
+++ b/src/lib/firebase/__tests__/uploadMedia.test.ts
@@ -1,0 +1,49 @@
+/** @jest-environment jsdom */
+import { uploadChatMedia } from '../uploadChatMedia';
+import { uploadMediaFile } from '../uploadMedia';
+import { uploadProfilePic } from '../uploadProfilePic';
+import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+
+jest.mock('../../firebase', () => ({ app: {} }));
+jest.mock('firebase/storage', () => ({
+  getStorage: jest.fn(),
+  ref: jest.fn(),
+  uploadBytes: jest.fn(),
+  getDownloadURL: jest.fn()
+}));
+
+const mockedGetStorage = getStorage as jest.MockedFunction<typeof getStorage>;
+const mockedRef = ref as jest.MockedFunction<typeof ref>;
+const mockedUploadBytes = uploadBytes as jest.MockedFunction<typeof uploadBytes>;
+const mockedGetDownloadURL = getDownloadURL as jest.MockedFunction<typeof getDownloadURL>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetStorage.mockReturnValue('storage' as any);
+  mockedRef.mockReturnValue('ref' as any);
+  mockedGetDownloadURL.mockResolvedValue('url');
+});
+
+test('uploadChatMedia', async () => {
+  const file = new File(['a'], 'chat.png');
+  const url = await uploadChatMedia('b1', file);
+  expect(mockedRef).toHaveBeenCalledWith('storage', expect.stringMatching(/^bookings\/b1\/\d+_chat.png$/));
+  expect(mockedUploadBytes).toHaveBeenCalledWith('ref', file);
+  expect(url).toBe('url');
+});
+
+test('uploadMediaFile', async () => {
+  const file = new File(['a'], 'media.png');
+  const url = await uploadMediaFile(file, 'u1', 'audio');
+  expect(mockedRef).toHaveBeenCalledWith('storage', 'users/u1/audio/media.png');
+  expect(mockedUploadBytes).toHaveBeenCalledWith('ref', file);
+  expect(url).toBe('url');
+});
+
+test('uploadProfilePic', async () => {
+  const file = new File(['a'], 'pic.png');
+  const url = await uploadProfilePic(file, 'u1');
+  expect(mockedRef).toHaveBeenCalledWith('storage', 'profile-pictures/u1');
+  expect(mockedUploadBytes).toHaveBeenCalledWith('ref', file);
+  expect(url).toBe('url');
+});


### PR DESCRIPTION
## Summary
- create `useSidebarToggle` tests
- cover `fetchUsers` Firestore helper
- test Firebase upload helpers
- add email helper tests
- add tracking utility tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ef08c0548328bd9053816fc2a050