### PR TITLE
Use clientId for contracts

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session;
     const bookingId = session.metadata?.bookingId;
-    const buyerId = session.metadata?.buyerId;
+    const clientId = session.metadata?.buyerId;
     const providerId = session.metadata?.providerId;
     const serviceName = session.metadata?.serviceName;
     const price = session.amount_total ? session.amount_total / 100 : undefined;
@@ -34,10 +34,10 @@ export async function POST(req: NextRequest) {
       await updateBookingStatus(bookingId, 'paid');
       await markAsHeld({ bookingId, userId: 'system', role: 'admin' });
 
-      if (buyerId && providerId && serviceName && price) {
+      if (clientId && providerId && serviceName && price) {
         const startDate = new Date().toISOString().split('T')[0];
         await generateContract(
-          { bookingId, buyerId, providerId, serviceName, price, startDate },
+          { bookingId, clientId, providerId, serviceName, price, startDate },
           'system'
         );
       }

--- a/src/lib/firestore/contracts/generateContract.ts
+++ b/src/lib/firestore/contracts/generateContract.ts
@@ -5,7 +5,7 @@ import { logActivity } from '@/lib/firestore/logging/logActivity';
 
 const contractSchema = z.object({
   bookingId: z.string().min(1),
-  buyerId: z.string().min(1),
+  clientId: z.string().min(1),
   providerId: z.string().min(1),
   serviceName: z.string().min(1),
   price: z.number().positive(),
@@ -24,7 +24,7 @@ export async function generateContract(
 
   const {
     bookingId,
-    buyerId,
+    clientId,
     providerId,
     serviceName,
     price,
@@ -32,7 +32,7 @@ export async function generateContract(
   } = parsed.data;
 
   // 🔐 Authorization check
-  if (![buyerId, providerId].includes(sessionUserId)) {
+  if (![clientId, providerId].includes(sessionUserId)) {
     console.warn('⚠️ Unauthorized contract generation attempt by:', sessionUserId);
     return { error: 'Unauthorized' };
   }
@@ -40,7 +40,7 @@ export async function generateContract(
   const contractText = `
     SERVICE AGREEMENT
 
-    This agreement is between ${buyerId} (Client) and ${providerId} (Provider).
+    This agreement is between ${clientId} (Client) and ${providerId} (Provider).
 
     The Provider agrees to deliver the service "${serviceName}" starting on ${startDate}, 
     in exchange for payment of $${price}.
@@ -53,7 +53,7 @@ export async function generateContract(
   try {
     await setDoc(doc(db, 'contracts', bookingId), {
       bookingId,
-      buyerId,
+      clientId,
       providerId,
       serviceName,
       price,
@@ -65,7 +65,7 @@ export async function generateContract(
     await logActivity(sessionUserId, 'contract_generated', {
       bookingId,
       providerId,
-      buyerId,
+      clientId,
       price,
       startDate,
     });


### PR DESCRIPTION
## Summary
- generate contracts using `clientId`
- update Stripe webhook to pass `clientId`

## Testing
- `npm test` *(fails: SMTP_EMAIL or SMTP_PASS is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845fcdbb59c8328afe32911202c3065