### PR TITLE
Add client and provider ids to chat messages

### DIFF
--- a/lib/firestore/messages.ts
+++ b/lib/firestore/messages.ts
@@ -8,7 +8,9 @@ import {
   serverTimestamp,
   getDocs,
   updateDoc,
-  limit
+  limit,
+  doc,
+  getDoc
 } from 'firebase/firestore';
 
 export const sendMessage = async (
@@ -19,6 +21,10 @@ export const sendMessage = async (
   mediaUrl: string | null = null
 ) => {
   const ref = collection(db, 'bookings', bookingId, 'messages');
+  const bookingSnap = await getDoc(doc(db, 'bookings', bookingId));
+  if (!bookingSnap.exists()) return;
+  const booking = bookingSnap.data() as any;
+
   await addDoc(ref, {
     senderId,
     senderName,
@@ -26,6 +32,8 @@ export const sendMessage = async (
     mediaUrl,
     timestamp: serverTimestamp(),
     seen: false,
+    clientId: booking.clientId,
+    providerId: booking.providerId,
   });
 };
 


### PR DESCRIPTION
## Summary
- include `clientId` and `providerId` in messages sent from `src/lib/firestore/chat/sendMessage.ts`
- write the same fields in the legacy messaging util in `lib/firestore/messages.ts`

## Testing
- `npm test` *(fails: SMTP_EMAIL or SMTP_PASS is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845fcca9bcc8328ace9a2cddea01198