### PR TITLE
Update booking field names

### DIFF
--- a/components/ProviderBookings.tsx
+++ b/components/ProviderBookings.tsx
@@ -41,7 +41,7 @@ export default function ProviderBookings() {
   };
 
   const handleMarkCompleted = async (booking: any) => {
-    await markBookingAsCompleted(booking.id, booking.clientUid, booking.providerUid);
+    await markBookingAsCompleted(booking.id, booking.clientId, booking.providerId);
     toast.success('Booking marked as completed. Review prompts sent.');
     fetchBookings();
   };

--- a/lib/createBooking.ts
+++ b/lib/createBooking.ts
@@ -8,14 +8,14 @@ const db = getFirestore(app)
 export async function createBooking({
   providerId,
   serviceId,
-  userId,
+  clientId,
   date,
   time,
   message
 }: {
   providerId: string
   serviceId: string
-  userId: string
+  clientId: string
   date: string
   time: string
   message: string
@@ -25,7 +25,7 @@ export async function createBooking({
     const docRef = await addDoc(bookingRef, {
       providerId,
       serviceId,
-      userId,
+      clientId,
       date,
       time,
       message,
@@ -38,7 +38,7 @@ export async function createBooking({
     // Store contract info too (optional)
     const contractRef = collection(db, "contracts")
     await addDoc(contractRef, {
-      clientId: userId,
+      clientId,
       providerId,
       bookingId,
       status: "pending",

--- a/src/app/components/BookingsViewer.js
+++ b/src/app/components/BookingsViewer.js
@@ -27,13 +27,13 @@ export default function BookingsViewer() {
 
   const loadMore = async (uid) => {
     setLoading(true);
-    const db = getFirestore(app);
-    const base = query(
-      collection(db, 'bookings'),
-      where('recipientUid', '==', uid),
-      orderBy('createdAt', 'desc'),
-      limit(10)
-    );
+      const db = getFirestore(app);
+      const base = query(
+        collection(db, 'bookings'),
+        where('providerId', '==', uid),
+        orderBy('createdAt', 'desc'),
+        limit(10)
+      );
     const q = lastDoc ? query(base, startAfter(lastDoc)) : base;
     const snapshot = await getDocs(q);
     const results = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
@@ -53,7 +53,7 @@ export default function BookingsViewer() {
         <ul className="space-y-4">
           {bookings.map((b) => (
             <li key={b.id} className="bg-gray-800 p-4 rounded shadow text-white">
-              <p><strong>From:</strong> {b.senderUid}</p>
+              <p><strong>From:</strong> {b.clientId}</p>
               <p><strong>Message:</strong> {b.message}</p>
               <p><strong>Time Slot:</strong> {b.timeSlot}</p>
               <p><strong>Status:</strong> {b.status}</p>

--- a/src/app/components/ClientBookings.js
+++ b/src/app/components/ClientBookings.js
@@ -15,10 +15,10 @@ export default function ClientBookings() {
     const user = auth.currentUser;
     if (!user) return;
 
-    const q = query(
-      collection(db, 'bookings'),
-      where('customerId', '==', user.uid)
-    );
+      const q = query(
+        collection(db, 'bookings'),
+        where('clientId', '==', user.uid)
+      );
 
     const unsubscribe = onSnapshot(q, (snapshot) => {
       const data = snapshot.docs.map((doc) => ({

--- a/src/app/components/ProviderBookings.js
+++ b/src/app/components/ProviderBookings.js
@@ -48,7 +48,7 @@ export default function ProviderBookings() {
             key={booking.id}
             className="border border-gray-600 p-4 rounded text-white"
           >
-            <p><strong>Customer ID:</strong> {booking.customerId}</p>
+            <p><strong>Customer ID:</strong> {booking.clientId}</p>
             <p><strong>Service:</strong> {booking.serviceName}</p>
             <p><strong>Price:</strong> ${booking.price}</p>
             <p><strong>Status:</strong> {booking.status}</p>

--- a/src/lib/firestore/saveBookingToFirestore.ts
+++ b/src/lib/firestore/saveBookingToFirestore.ts
@@ -8,8 +8,8 @@ import { isProfileComplete } from '@/lib/profile/isProfileComplete';
 
 type BookingData = {
   id: string;
-  clientUid: string;
-  providerUid: string;
+  clientId: string;
+  providerId: string;
   providerProfile: UserProfile;
   serviceId: string;
   serviceName: string;
@@ -38,10 +38,15 @@ export async function saveBookingToFirestore(bookingData: BookingData, clientEma
   });
 
   await sendBookingConfirmation(clientEmail, bookingData.id);
-  await createNotification(bookingData.clientUid, 'booking_created', 'Your booking request has been sent!', bookingData.id);
+  await createNotification(
+    bookingData.clientId,
+    'booking_created',
+    'Your booking request has been sent!',
+    bookingData.id
+  );
 
-  await logActivity(bookingData.clientUid, 'booking_created', {
-    providerId: bookingData.providerUid,
+  await logActivity(bookingData.clientId, 'booking_created', {
+    providerId: bookingData.providerId,
     serviceId: bookingData.serviceId,
     date: bookingData.datetime,
   });

--- a/src/types/booking.ts
+++ b/src/types/booking.ts
@@ -8,8 +8,8 @@ export interface BookingContract {
 
 export interface Booking {
   id: string;
-  clientUid: string;
-  providerUid: string;
+  clientId: string;
+  providerId: string;
   serviceId: string;
   serviceName: string;
   datetime: string;


### PR DESCRIPTION
## Summary
- use `clientId` and `providerId` across booking components
- rename booking type fields accordingly
- fix ProviderBookings to send correct IDs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fcc2e9b48328b74a4695ca030e06