### PR TITLE
Fix review authorId storage

### DIFF
--- a/src/lib/firestore/reviews/submitReview.ts
+++ b/src/lib/firestore/reviews/submitReview.ts
@@ -47,6 +47,7 @@ export async function submitReview(review: Review) {
   const reviewData = {
     ...review,
     createdAt: serverTimestamp(),
+    authorId: review.clientId,
   };
 
   // Write to contract thread
@@ -62,6 +63,7 @@ export async function submitReview(review: Review) {
     addDoc(globalReviewsRef, {
       ...reviewData,
       providerId: review.providerId,
+      authorId: review.clientId,
     }),
     updateDoc(doc(db, 'bookings', review.bookingId), { hasReview: true }),
   ]);


### PR DESCRIPTION
## Summary
- include `authorId` when recording review documents
- keep authorId in contract and profile subcollections

## Testing
- `SMTP_EMAIL=test SMTP_PASS=test npm test` *(fails: sendEmail.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc95224c83289390304e668c3e90