### PR TITLE
Fix activity log path

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -64,7 +64,7 @@ service cloud.firestore {
     }
 
     // Logs
-    match /activityLogs/{userId} {
+    match /activityLogs/{userId}/{logId} {
       allow create: if request.auth != null && request.auth.uid == userId;
       allow read: if request.auth != null && request.auth.token.admin == true;
     }

--- a/src/lib/firestore/logging/logActivity.ts
+++ b/src/lib/firestore/logging/logActivity.ts
@@ -24,7 +24,7 @@ export async function logActivity(
   };
 
   try {
-    await addDoc(collection(db, 'activityLogs', uid, 'logs'), payload);
+    await addDoc(collection(db, 'activityLogs', uid), payload);
 
     // Award points for key actions
     if (actionType === 'booking_completed') {


### PR DESCRIPTION
## Summary
- update firestore rules for activity logs
- log user activity under `/activityLogs/{uid}` subcollections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc97b3b08328a3562144e7aaf663