### PR TITLE
Fix upcoming bookings query

### DIFF
--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -11,7 +11,7 @@ const db = getFirestore(app);
 async function getBookings(req: NextRequest) {
   const user = await getServerUser(req)
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const snap = await getDocs(collection(db, 'bookingRequests'));
+  const snap = await getDocs(collection(db, 'bookings'));
   const bookings = snap.docs.map(d => ({ id: d.id, ...d.data() }));
   return NextResponse.json(bookings);
 }
@@ -26,7 +26,7 @@ async function updateBooking(req: NextRequest) {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
   }
 
-  const ref = doc(db, 'bookingRequests', id);
+  const ref = doc(db, 'bookings', id);
   await updateDoc(ref, { status });
   return NextResponse.json({ success: true });
 }

--- a/src/app/dashboard/upcoming/page.tsx
+++ b/src/app/dashboard/upcoming/page.tsx
@@ -14,12 +14,12 @@ export default function UpcomingBookingsPage() {
     const fetchBookings = async () => {
       if (!user?.uid) return;
       const db = getFirestore(app);
-      const ref = collection(db, 'bookingRequests');
+      const ref = collection(db, 'bookings');
       const q = query(
         ref,
         where('providerId', '==', user.uid),
         where('status', '==', 'pending'),
-        orderBy('selectedTime', 'asc')
+        orderBy('dateTime', 'asc')
       );
       const snap = await getDocs(q);
       setBookings(snap.docs.map(doc => ({ id: doc.id, ...doc.data() })));
@@ -43,7 +43,7 @@ export default function UpcomingBookingsPage() {
             {bookings.map((b) => (
               <li key={b.id} className="border p-4 rounded">
                 <p><strong>Client ID:</strong> {b.clientId}</p>
-                <p><strong>Time Slot:</strong> {b.selectedTime}</p>
+                <p><strong>Time Slot:</strong> {b.dateTime}</p>
                 <p><strong>Message:</strong> {b.message}</p>
                 {b.providerLocation && (
                   <p><strong>📍 Location:</strong> {b.providerLocation}</p>


### PR DESCRIPTION
## Summary
- fetch provider upcoming bookings from `bookings` collection
- update bookings API to read/write `bookings`

## Testing
- `npm test` *(fails: SMTP_EMAIL or SMTP_PASS is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845fcb48cec8328b8b86e42c32cc6f3