### PR TITLE
Fix notification helpers

### DIFF
--- a/src/lib/firestore/createNotification.ts
+++ b/src/lib/firestore/createNotification.ts
@@ -1,9 +1,11 @@
 import { db } from '@lib/firebase/init';
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
 
 export async function createNotification(uid: string, type: string, message: string, relatedId: string) {
   try {
-    await addDoc(collection(db, 'notifications', uid, 'messages'), {
+    const ref = doc(db, 'notifications', uid);
+    await setDoc(ref, {
+      userId: uid,
       type,
       message,
       relatedId,

--- a/src/lib/notifications/sendInAppNotification.ts
+++ b/src/lib/notifications/sendInAppNotification.ts
@@ -1,4 +1,4 @@
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore'
 import { db } from '@/lib/firebase'
 
 type NotificationType =
@@ -20,7 +20,9 @@ export async function sendInAppNotification({
   message: string
   link: string
 }) {
-  await addDoc(collection(db, 'users', to, 'notifications'), {
+  const ref = doc(db, 'notifications', to)
+  await setDoc(ref, {
+    userId: to,
     type,
     title,
     message,


### PR DESCRIPTION
## Summary
- centralize storage for notifications
- use direct Firestore doc path for notifications

## Testing
- `npm test` *(fails: Email tests depend on SMTP variables)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc9d4a5c8328b6fa971e49d19fc7