### PR TITLE
Fix SendGrid env validation

### DIFF
--- a/__tests__/sendEmailNotification.test.ts
+++ b/__tests__/sendEmailNotification.test.ts
@@ -26,16 +26,28 @@ describe('sendEmailNotification env validation', () => {
     delete process.env.SENDGRID_API_KEY
     process.env.SENDGRID_FROM_EMAIL = 'from@example.com'
 
-    await expect(import('@/lib/notifications/sendEmailNotification'))
-      .rejects.toThrow('SENDGRID_API_KEY is not defined')
+    const module = await import('@/lib/notifications/sendEmailNotification')
+    await expect(
+      module.sendEmailNotification({
+        to: 'to@example.com',
+        subject: 'Sub',
+        text: 'hi'
+      })
+    ).rejects.toThrow('SENDGRID_API_KEY is not defined')
   })
 
   test('throws when SENDGRID_FROM_EMAIL is missing', async () => {
     process.env.SENDGRID_API_KEY = 'key'
     delete process.env.SENDGRID_FROM_EMAIL
 
-    await expect(import('@/lib/notifications/sendEmailNotification'))
-      .rejects.toThrow('SENDGRID_FROM_EMAIL is not defined')
+    const module = await import('@/lib/notifications/sendEmailNotification')
+    await expect(
+      module.sendEmailNotification({
+        to: 'to@example.com',
+        subject: 'Sub',
+        text: 'hi'
+      })
+    ).rejects.toThrow('SENDGRID_FROM_EMAIL is not defined')
   })
 
   test('sends when variables are defined', async () => {

--- a/src/lib/notifications/sendEmailNotification.ts
+++ b/src/lib/notifications/sendEmailNotification.ts
@@ -1,21 +1,6 @@
 import sgMail from '@sendgrid/mail'
 
-const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY
-const SENDGRID_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL
-
-if (!SENDGRID_API_KEY) {
-  const msg = 'SENDGRID_API_KEY is not defined'
-  console.error(msg)
-  throw new Error(msg)
-}
-
-if (!SENDGRID_FROM_EMAIL) {
-  const msg = 'SENDGRID_FROM_EMAIL is not defined'
-  console.error(msg)
-  throw new Error(msg)
-}
-
-sgMail.setApiKey(SENDGRID_API_KEY)
+let apiKeySet = false
 
 export async function sendEmailNotification({
   to,
@@ -28,10 +13,30 @@ export async function sendEmailNotification({
   text: string
   html?: string
 }) {
+  const apiKey = process.env.SENDGRID_API_KEY
+  const fromEmail = process.env.SENDGRID_FROM_EMAIL
+
+  if (!apiKey) {
+    const msg = 'SENDGRID_API_KEY is not defined'
+    console.error(msg)
+    throw new Error(msg)
+  }
+
+  if (!fromEmail) {
+    const msg = 'SENDGRID_FROM_EMAIL is not defined'
+    console.error(msg)
+    throw new Error(msg)
+  }
+
+  if (!apiKeySet) {
+    sgMail.setApiKey(apiKey)
+    apiKeySet = true
+  }
+
   try {
     await sgMail.send({
       to,
-      from: SENDGRID_FROM_EMAIL as string,
+      from: fromEmail,
       subject,
       text,
       html: html || `<p>${text}</p>`


### PR DESCRIPTION
## Summary
- validate SendGrid variables when sending mail, not at import
- update sendEmailNotification tests
- set SendGrid API key once per process

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fbdfa0b883288bf4f282ce799e76