### PR TITLE
Update saved filter storage

### DIFF
--- a/__tests__/savedFilters.test.ts
+++ b/__tests__/savedFilters.test.ts
@@ -8,6 +8,8 @@ import {
   serverTimestamp,
   doc,
   deleteDoc,
+  query,
+  where,
 } from 'firebase/firestore';
 
 jest.mock('@/lib/firebase', () => ({ app: {} }));
@@ -20,20 +22,27 @@ jest.mock('firebase/firestore', () => ({
   serverTimestamp: jest.fn(() => 'ts'),
   doc: jest.fn(),
   deleteDoc: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
 }));
 
 const mockedCollection = collection as jest.MockedFunction<typeof collection>;
 const mockedAddDoc = addDoc as jest.MockedFunction<typeof addDoc>;
 const mockedGetDocs = getDocs as jest.MockedFunction<typeof getDocs>;
+const mockedQuery = query as jest.MockedFunction<typeof query>;
+const mockedWhere = where as jest.MockedFunction<typeof where>;
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockedCollection.mockReturnValue('col' as any);
+  mockedQuery.mockReturnValue('q' as any);
+  mockedWhere.mockReturnValue('w' as any);
 });
 
 test('save -> fetch -> apply', async () => {
   await createFilterPreset('u1', 'test', { role: 'artist' });
   expect(mockedAddDoc).toHaveBeenCalledWith('col', {
+    userId: 'u1',
     name: 'test',
     filtersJson: JSON.stringify({ role: 'artist' }),
     createdAt: 'ts',
@@ -43,7 +52,11 @@ test('save -> fetch -> apply', async () => {
     docs: [
       {
         id: 'id1',
-        data: () => ({ name: 'test', filtersJson: JSON.stringify({ role: 'artist' }) }),
+        data: () => ({
+          name: 'test',
+          filtersJson: JSON.stringify({ role: 'artist' }),
+          userId: 'u1',
+        }),
       },
     ],
   } as any);

--- a/src/lib/email/__tests__/sendEmail.test.ts
+++ b/src/lib/email/__tests__/sendEmail.test.ts
@@ -1,4 +1,3 @@
-import { sendEmail } from '../sendEmail';
 import nodemailer from 'nodemailer';
 import fs from 'fs';
 import path from 'path';
@@ -14,11 +13,13 @@ const sendMail = jest.fn();
 
 afterEach(() => {
   jest.clearAllMocks();
+  jest.resetModules();
 });
 
 test('sends email and returns success', async () => {
   sendMail.mockResolvedValue({ messageId: '1' });
   process.env.SMTP_EMAIL = 'from@test.com';
+  const { sendEmail } = require('../sendEmail');
   const res = await sendEmail('to@test.com', 'Sub', 'welcome.html', { name: 'A' });
   expect(path.join).toHaveBeenCalled();
   expect(fs.readFileSync).toHaveBeenCalledWith('/template.html', 'utf-8');
@@ -34,6 +35,7 @@ test('sends email and returns success', async () => {
 
 test('returns error on failure', async () => {
   sendMail.mockRejectedValue(new Error('fail'));
+  const { sendEmail } = require('../sendEmail');
   const res = await sendEmail('to@test.com', 'Sub', 't.html', {});
   expect(res).toEqual({ error: 'Email send failed' });
 });


### PR DESCRIPTION
## Summary
- store saved filter presets in a shared `savedFilters` collection
- include `userId` in documents
- query and delete presets by `userId`
- adjust tests for new document shape
- fix nodemailer mock ordering in email tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845fc8617d08328a1fda2a1ed619cad