### PR TITLE
feat: empty-state copy for DiscoveryGrid

### DIFF
--- a/src/components/explore/DiscoveryGrid.tsx
+++ b/src/components/explore/DiscoveryGrid.tsx
@@ -58,12 +58,12 @@ export default function DiscoveryGrid({ filters }: { filters: any }) {
       }
     };
     window.addEventListener('scroll', onScroll);
-  if (data && data.pages[0].results.length === 0) return (<p className="p-4 text-gray-400">No creators found.<\/p>);
+    return () => window.removeEventListener('scroll', onScroll);
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
   const router = useRouter();
 
   if (isLoading)
-  if (data && data.pages[0].results.length === 0) return (<p className="p-4 text-gray-400">No creators found.<\/p>);
+    return (
       <div className="text-white">
         <Translate t="explore.loadingResults" />
       </div>
@@ -71,7 +71,10 @@ export default function DiscoveryGrid({ filters }: { filters: any }) {
 
   const creators = data?.pages.flatMap(p => p.results) ?? [];
 
-  if (data && data.pages[0].results.length === 0) return (<p className="p-4 text-gray-400">No creators found.<\/p>);
+  if (data?.pages?.[0]?.results?.length === 0)
+    return <p className="p-4 text-gray-400">No creators found.</p>;
+
+  return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
       {creators.map((creator: any) => (
         <div


### PR DESCRIPTION
## Summary
- fix DiscoveryGrid logic to clean up scroll listener
- show a friendly message when no creators are returned

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac4342c6883288421a69bc947bee1