### PR TITLE
feat: skeleton placeholders for chat & leaderboard

### DIFF
--- a/src/components/booking/BookingChat.tsx
+++ b/src/components/booking/BookingChat.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import Skeleton from 'react-loading-skeleton';
 import {
   collection,
   query,
@@ -31,6 +32,7 @@ type Props = {
 export default function BookingChat({ bookingId }: Props) {
   const { user } = useAuth();
   const [messages, setMessages] = useState<Message[]>([]);
+  const [isLoading, setLoading] = useState(true);
   const [text, setText] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [isTyping, setTyping] = useState(false);
@@ -52,6 +54,7 @@ export default function BookingChat({ bookingId }: Props) {
 
   useEffect(() => {
     if (!bookingId) return;
+    setLoading(true);
     const q = query(
       collection(db, 'bookings', bookingId, 'messages'),
       orderBy('createdAt', 'asc')
@@ -59,6 +62,7 @@ export default function BookingChat({ bookingId }: Props) {
     const unsub = onSnapshot(q, snap => {
       const msgs = snap.docs.map(d => ({ id: d.id, ...(d.data() as any) }));
       setMessages(msgs);
+      setLoading(false);
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
       if (user?.uid) markMessagesAsSeen(bookingId, user.uid);
     });
@@ -104,6 +108,10 @@ export default function BookingChat({ bookingId }: Props) {
     setFile(null);
     setTypingStatus(bookingId, user.uid, false);
   };
+
+  if (isLoading && messages.length === 0) {
+    return <Skeleton count={5} height={32} className="mb-2 rounded" />;
+  }
 
   return (
     <div className="space-y-4">

--- a/src/components/leaderboard/LeaderboardList.tsx
+++ b/src/components/leaderboard/LeaderboardList.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Skeleton from 'react-loading-skeleton';
+import { fetchLeaderboard, LeaderboardEntry } from '@/lib/leaderboards';
+
+export default function LeaderboardList({ period }: { period: 'weekly' | 'monthly' }) {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchLeaderboard(period)
+      .then(data => setEntries(data))
+      .finally(() => setLoading(false));
+  }, [period]);
+
+  if (loading && entries.length === 0) {
+    return <Skeleton count={6} height={48} className="mb-2 rounded" />;
+  }
+
+  if (entries.length === 0) {
+    return <p className="text-sm text-gray-400">No entries</p>;
+  }
+
+  return (
+    <ol className="space-y-2">
+      {entries.map((e, i) => (
+        <li key={e.uid} className="border border-neutral-700 p-2 rounded">
+          #{i + 1} {e.uid} - {e.points} XP
+        </li>
+      ))}
+    </ol>
+  );
+}


### PR DESCRIPTION
## Summary
- add Skeleton loader to BookingChat when loading messages
- include LeaderboardList component with skeleton fallback

## Testing
- `npm test -- --runInBand --ci`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbf0de0988328addde1defce2542d