### PR TITLE
feat: leaderboard empty state

### DIFF
--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -18,6 +18,12 @@ export default function LeaderboardPage() {
     load()
   }, [])
 
+  if (!entries?.length) {
+    return (
+      <p className="p-6 text-center text-gray-400">No scores this week — check back soon!</p>
+    )
+  }
+
   return (
     <div className="min-h-screen bg-black text-white p-6">
       <h1 className="text-3xl font-bold mb-4">Weekly Leaderboard</h1>


### PR DESCRIPTION
## Summary
- add a graceful message when no leaderboard entries are found

## Testing
- `npm test -- --runInBand --ci`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbef42f708328b55bb5a73400f439