### PR TITLE
feat: add featured creators row

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -14,11 +14,15 @@ const DiscoveryMap = dynamic(() => import('@/components/explore/DiscoveryMap'), 
 });
 import { useFeatureFlag } from '@/lib/hooks/useFeatureFlag';
 import FloatingCartButton from '@/components/cart/FloatingCartButton';
+import CreatorCard from '@/components/cards/CreatorCard';
+import { getFeaturedCreators } from '@/lib/firestore/getFeaturedCreators';
 
 export default function ExplorePage() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const newExplore = useFeatureFlag('newExplore');
+
+  const [featured, setFeatured] = useState<any[]>([]);
 
   const [view, setView] = useState<'grid' | 'map'>(
     searchParams.get('view') === 'map' ? 'map' : 'grid'
@@ -44,6 +48,10 @@ export default function ExplorePage() {
     radiusKm: searchParams.get('radiusKm') ? parseInt(searchParams.get('radiusKm')!, 10) : 50,
     sort: (searchParams.get('sort') as 'rating' | 'distance' | 'popularity') || 'rating',
   });
+
+  useEffect(() => {
+    getFeaturedCreators().then(setFeatured).catch(() => setFeatured([]));
+  }, []);
 
   useEffect(() => {
     const query = new URLSearchParams();
@@ -92,6 +100,29 @@ export default function ExplorePage() {
       </div>
 
       <FilterPanel filters={filters} setFilters={setFilters} />
+
+      {featured.length > 0 && (
+        <section className="mb-6">
+          <h2 className="text-xl font-bold mb-2">🔥 Featured Creators</h2>
+          <div className="flex gap-4 overflow-x-auto pb-2 sm:grid sm:grid-cols-2 sm:gap-4">
+            {featured.map(c => (
+              <div key={c.uid} className="min-w-[220px]">
+                <CreatorCard
+                  id={c.uid}
+                  name={c.displayName || c.name || 'Unnamed'}
+                  tagline={c.bio}
+                  price={c.price}
+                  location={c.location}
+                  imageUrl={c.photoURL}
+                  rating={c.averageRating}
+                  reviewCount={c.reviewCount}
+                  proTier={c.proTier}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {view === 'grid' ? (
         newExplore ? (

--- a/src/lib/firestore/getFeaturedCreators.ts
+++ b/src/lib/firestore/getFeaturedCreators.ts
@@ -1,0 +1,14 @@
+import { getFirestore, collection, query, where, orderBy, limit, getDocs } from 'firebase/firestore';
+import { app } from '@/lib/firebase';
+
+export async function getFeaturedCreators() {
+  const db = getFirestore(app);
+  const q = query(
+    collection(db, 'users'),
+    where('verified', '==', true),
+    orderBy('averageRating', 'desc'),
+    limit(4)
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map(doc => ({ uid: doc.id, ...(doc.data() as any) }));
+}


### PR DESCRIPTION
## Summary
- feature highlight: add Featured Creators row on explore page
- fetch top 4 highest-rated verified users via new helper
- display cards before discovery grid

## Testing
- `npm test -- --runInBand --ci` *(fails: jest not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bd5148e548328ad29f28e342c4294