### PR TITLE
feat/mobile-filter-drawer

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -14,6 +14,7 @@ const DiscoveryMap = dynamic(() => import('@/components/explore/DiscoveryMap'), 
 });
 import { useFeatureFlag } from '@/lib/hooks/useFeatureFlag';
 import FloatingCartButton from '@/components/cart/FloatingCartButton';
+import useIsMobile from '@/lib/hooks/useIsMobile';
 
 export default function ExplorePage() {
   const searchParams = useSearchParams();
@@ -21,18 +22,12 @@ export default function ExplorePage() {
   const newExplore = useFeatureFlag('newExplore');
 
   const [filtersOpen, setFiltersOpen] = useState(true);
-  const [isMobile, setIsMobile] = useState(false);
+  const isMobile = useIsMobile(768);
 
-  // Collapse filters by default on small screens
+  // Collapse or expand when screen size changes
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const mobile = window.innerWidth < 768;
-      setIsMobile(mobile);
-      if (mobile) {
-        setFiltersOpen(false);
-      }
-    }
-  }, []);
+    setFiltersOpen(!isMobile);
+  }, [isMobile]);
 
   const [view, setView] = useState<'grid' | 'map'>(
     searchParams.get('view') === 'map' ? 'map' : 'grid'

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -20,6 +20,20 @@ export default function ExplorePage() {
   const router = useRouter();
   const newExplore = useFeatureFlag('newExplore');
 
+  const [filtersOpen, setFiltersOpen] = useState(true);
+  const [isMobile, setIsMobile] = useState(false);
+
+  // Collapse filters by default on small screens
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const mobile = window.innerWidth < 768;
+      setIsMobile(mobile);
+      if (mobile) {
+        setFiltersOpen(false);
+      }
+    }
+  }, []);
+
   const [view, setView] = useState<'grid' | 'map'>(
     searchParams.get('view') === 'map' ? 'map' : 'grid'
   );
@@ -91,7 +105,28 @@ export default function ExplorePage() {
         </div>
       </div>
 
-      <FilterPanel filters={filters} setFilters={setFilters} />
+      {!filtersOpen && (
+        <button
+          onClick={() => setFiltersOpen(true)}
+          className="btn btn-sm mb-4"
+        >
+          Show Filters
+        </button>
+      )}
+
+      {filtersOpen && (
+        <div className="mb-4">
+          {isMobile && (
+            <button
+              onClick={() => setFiltersOpen(false)}
+              className="btn btn-sm mb-2"
+            >
+              Hide Filters
+            </button>
+          )}
+          <FilterPanel filters={filters} setFilters={setFilters} />
+        </div>
+      )}
 
       {view === 'grid' ? (
         newExplore ? (

--- a/src/lib/hooks/useIsMobile.ts
+++ b/src/lib/hooks/useIsMobile.ts
@@ -1,0 +1,17 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const query = window.matchMedia(`(max-width:${breakpoint}px)`);
+    const update = () => setIsMobile(query.matches);
+    update();
+    query.addEventListener('change', update);
+    return () => query.removeEventListener('change', update);
+  }, [breakpoint]);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary
- add responsive filter drawer toggle to Explore page

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test -- --runInBand --ci` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd5297c208328b8070cfa0d11a306