### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/src/app/api/healthz/route.ts
+++ b/src/app/api/healthz/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok', uptime: process.uptime() })
+}


### PR DESCRIPTION
## Summary
- add a simple `/api/healthz` route that returns uptime

## Testing
- `npm test -- --runInBand --ci`

------
https://chatgpt.com/codex/tasks/task_e_684bd55809b483288c4694811a6165b7