### PR TITLE
feat/lazy-stripe-elements

### DIFF
--- a/components/StripeCheckout.tsx
+++ b/components/StripeCheckout.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { loadStripe } from '@stripe/stripe-js';
-import { Elements } from '@stripe/react-stripe-js';
 import { useRouter } from 'next/navigation';
 
 // ✅ Define the stripePromise using your public key

--- a/src/components/checkout/StripeWrapper.tsx
+++ b/src/components/checkout/StripeWrapper.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import React from 'react'
+import dynamic from 'next/dynamic'
+import { loadStripe } from '@stripe/stripe-js'
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!)
+
+const Elements = dynamic(() => import('@stripe/react-stripe-js').then(m => m.Elements), {
+  ssr: false,
+})
+
+export default function StripeWrapper({ children }: { children: React.ReactNode }) {
+  return <Elements stripe={stripePromise}>{children}</Elements>
+}


### PR DESCRIPTION
## Summary
- lazy-load Stripe Elements in a dynamic chunk

## Testing
- `npm test -- --runInBand --ci`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbeea62608328b32739fa42676b78