### PR TITLE
Add tour tooltip component

### DIFF
--- a/src/components/onboarding/TourTooltip.tsx
+++ b/src/components/onboarding/TourTooltip.tsx
@@ -1,0 +1,29 @@
+'use client'
+import React from 'react'
+import { useTour } from '@/context/TourContext'
+import { motion } from 'framer-motion'
+
+export default function TourTooltip() {
+  const { step, nextStep } = useTour()
+
+  const steps = [
+    { text: 'Welcome to AuditoryX. Let me show you around.' },
+    { text: 'This is your dashboard — everything lives here.' },
+    { text: 'Click anything to start creating magic.' },
+  ]
+
+  if (step >= steps.length) return null
+
+  return (
+    <motion.div
+      className="fixed bottom-10 left-1/2 transform -translate-x-1/2 bg-white px-4 py-3 rounded-xl shadow-xl max-w-sm text-black"
+      initial={{ opacity: 0, y: 40 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0 }}
+      onClick={nextStep}
+    >
+      <p className="text-sm">{steps[step].text}</p>
+      <p className="text-xs text-right mt-2 text-gray-500">Click to continue</p>
+    </motion.div>
+  )
+}

--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -1,0 +1,25 @@
+'use client'
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+type TourContextType = {
+  step: number
+  nextStep: () => void
+}
+
+const TourContext = createContext<TourContextType>({
+  step: 0,
+  nextStep: () => {},
+})
+
+export const TourProvider = ({ children }: { children: ReactNode }) => {
+  const [step, setStep] = useState(0)
+  const nextStep = () => setStep((prev) => prev + 1)
+
+  return (
+    <TourContext.Provider value={{ step, nextStep }}>
+      {children}
+    </TourContext.Provider>
+  )
+}
+
+export const useTour = () => useContext(TourContext)


### PR DESCRIPTION
## Summary
- add minimal `TourContext` with step logic
- add `TourTooltip` component showing onboarding text

## Testing
- `npm test -- --runInBand --ci`

------
https://chatgpt.com/codex/tasks/task_e_6854459fbe648328959f9aee2677ab53