### PR TITLE
Add TourProvider context and integrate with root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Metadata } from 'next';
 import { LanguageProvider } from '@/context/LanguageContext';
 import { AuthProvider } from '@/context/AuthContext';
 import { CartProvider } from '@/context/CartContext';
+import { TourProvider } from '@/context/TourContext';
 import { Toaster } from 'react-hot-toast';
 import QueryProvider from '../../providers/QueryProvider';
 import StreakToast from '../components/gamification/StreakToast';
@@ -33,20 +34,21 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <AuthProvider>
-          <LanguageProvider>
-            <CartProvider>
-              <QueryProvider>
-                <Toaster position="top-center" />
-                <StreakToast />
-                <OnboardingTour />
-                <Navbar />
-                {children}
-              </QueryProvider>
-            </CartProvider>
-          </LanguageProvider>
-        </div>
-        </AuthProvider>
+        <TourProvider>
+          <AuthProvider>
+            <LanguageProvider>
+              <CartProvider>
+                <QueryProvider>
+                  <Toaster position="top-center" />
+                  <StreakToast />
+                  <OnboardingTour />
+                  <Navbar />
+                  {children}
+                </QueryProvider>
+              </CartProvider>
+            </LanguageProvider>
+          </AuthProvider>
+        </TourProvider>
       </body>
     </html>
   );

--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { createContext, useContext, useState } from 'react'
+
+interface TourContextType {
+  run: boolean
+  startTour: () => void
+  stopTour: () => void
+}
+
+const TourContext = createContext<TourContextType>({
+  run: false,
+  startTour: () => {},
+  stopTour: () => {},
+})
+
+export const TourProvider = ({ children }: { children: React.ReactNode }) => {
+  const [run, setRun] = useState(false)
+
+  const startTour = () => setRun(true)
+  const stopTour = () => setRun(false)
+
+  return (
+    <TourContext.Provider value={{ run, startTour, stopTour }}>
+      {children}
+    </TourContext.Provider>
+  )
+}
+
+export const useTour = () => useContext(TourContext)


### PR DESCRIPTION
## Summary
- create `TourContext` with `TourProvider`
- wrap root layout `<body>` in `TourProvider` and fix stray div

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test -- --runInBand --ci`

------
https://chatgpt.com/codex/tasks/task_e_68544596e5a08328a352209121bcf3bd