### PR TITLE
feat: add Tour context hook

### DIFF
--- a/src/context/TourContext.tsx
+++ b/src/context/TourContext.tsx
@@ -1,0 +1,27 @@
+'use client'
+import React, { createContext, useContext, useState } from 'react'
+
+type TourContextType = {
+  step: number
+  setStep: (s: number) => void
+  nextStep: () => void
+}
+
+const TourContext = createContext<TourContextType | undefined>(undefined)
+
+export const TourProvider = ({ children }: { children: React.ReactNode }) => {
+  const [step, setStep] = useState(0)
+  const nextStep = () => setStep((s) => s + 1)
+
+  return (
+    <TourContext.Provider value={{ step, setStep, nextStep }}>
+      {children}
+    </TourContext.Provider>
+  )
+}
+
+export const useTour = () => {
+  const ctx = useContext(TourContext)
+  if (!ctx) throw new Error('useTour must be used within TourProvider')
+  return ctx
+}


### PR DESCRIPTION
## Summary
- add context to manage onboarding tour steps

## Testing
- `npm ci --prefer-offline --legacy-peer-deps`
- `npm test -- --runInBand --ci`


------
https://chatgpt.com/codex/tasks/task_e_685445902a348328a0180923e659ddb9