### PR TITLE
Refactor user metrics placement

### DIFF
--- a/__tests__/useProfileCompletion.test.ts
+++ b/__tests__/useProfileCompletion.test.ts
@@ -11,12 +11,10 @@ function createProfile(overrides: Partial<UserProfile> = {}): UserProfile {
     media: [],
     availability: [],
     socials: {},
-    isVerified: false,
     verificationStatus: undefined,
     status: 'approved',
     createdAt: null,
     timezone: 'UTC',
-    points: 0,
     ...overrides,
   } as UserProfile;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -14,7 +14,6 @@ export interface UserProfile {
     twitter?: string;
     spotify?: string;
   };
-  isVerified: boolean;
   /**
    * Status of the user's ID verification request. If undefined, no verification
    * has been submitted yet.
@@ -23,10 +22,6 @@ export interface UserProfile {
   status: 'approved' | 'rejected';
   createdAt: any;
   timezone: string; // ✅ Required for isProfileComplete
-  /**
-   * Community contribution points. Starts at 0.
-   */
-  points?: number;
   /** Rooms for studio profiles */
   rooms?: Room[];
 }
@@ -47,6 +42,9 @@ export interface User {
   photoURL: string;
   providerId: string;
   role: 'creator' | 'admin' | 'user';
+  /** Whether the user has completed ID verification */
+  isVerified?: boolean;
+  proTier?: 'standard' | 'verified' | 'signature';
   isVisible?: boolean; // ✅ Optional for isProfileComplete
   /**
    * Total XP points accumulated by the user.


### PR DESCRIPTION
## Summary
- keep metrics on the top-level `User` document
- remove duplicate fields from `UserProfile`
- adjust profile completion tests

## Testing
- `npm ci --legacy-peer-deps`
- `npm test -- --runInBand --ci`

------
https://chatgpt.com/codex/tasks/task_e_6857ae327c3883289d9fbbdb36efa112