### PR TITLE
feat: centralize gamification values

### DIFF
--- a/src/constants/gamification.ts
+++ b/src/constants/gamification.ts
@@ -1,0 +1,18 @@
+import { GamificationEvent } from '@/lib/gamification'
+
+/** XP rewards per event (single source of truth). */
+export const XP_VALUES: Record<GamificationEvent, number> = {
+  bookingConfirmed: 50,
+  fiveStarReview: 100,
+  onTimeDelivery: 25,
+  sevenDayStreak: 40,
+  creatorReferral: 150,
+}
+
+/** Numeric weight multiplier used in rankScore formula. */
+export const TIER_WEIGHT: Record<UserTier, number> = {
+  signature: 1.0,
+  verified: 0.8,
+  standard: 0.5,
+}
+


### PR DESCRIPTION
## Summary
- add gamification constants for XP rewards and tier weight

## Testing
- `pnpm install`
- `npm test -- --runInBand --ci`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857b75a65c48328876c74cb56a93987