### PR TITLE
Task 4 gamification utilities

### DIFF
--- a/__tests__/abuse.test.ts
+++ b/__tests__/abuse.test.ts
@@ -35,12 +35,12 @@ describe('abuse detection', () => {
     mockedWhere.mockReturnValue('whereRef' as any)
     mockedTimestampFromDate.mockReturnValue('startTs')
     mockedGetDocs.mockResolvedValue({ docs: [] } as any)
-    mockedGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ points: 0, streakCount: 0 }) } as any)
+    mockedGetDoc.mockResolvedValue({ exists: () => true, data: () => ({ xp: 0, streakCount: 0 }) } as any)
   })
 
   test('prevents duplicate context events', async () => {
     mockedGetDocs.mockResolvedValueOnce({ empty: false, docs: [{}] } as any)
-    const awarded = await logXpEvent('u1', 10, 'test', { contextId: 'abc' })
+    const awarded = await logXpEvent('u1', 'bookingConfirmed', { contextId: 'abc' })
     expect(awarded).toBe(0)
     expect(mockedAddDoc).toHaveBeenCalledWith('collRef', expect.objectContaining({ contextId: 'abc' }))
   })

--- a/__tests__/referrals.test.ts
+++ b/__tests__/referrals.test.ts
@@ -65,7 +65,7 @@ describe('referral helpers', () => {
     const ok = await redeemReferralCode('u2', 'CODE')
     expect(ok).toBe(true)
     expect(mockedUpdateDoc).toHaveBeenCalledTimes(2)
-    expect(mockedLogXp).toHaveBeenCalledWith('u2', 500, 'referral')
+    expect(mockedLogXp).toHaveBeenCalledWith('u2', 'creatorReferral')
   })
 
   test('fails for invalid code', async () => {

--- a/src/lib/referrals.ts
+++ b/src/lib/referrals.ts
@@ -12,8 +12,6 @@ import {
 } from 'firebase/firestore'
 import { logXpEvent } from '@/lib/gamification'
 
-const REFERRAL_XP = 500
-
 async function getReferralCode(uid: string): Promise<string | null> {
   const codesRef = collection(db, 'referralCodes')
   const q = query(codesRef, where('ownerId', '==', uid))
@@ -49,6 +47,6 @@ export async function redeemReferralCode(
 
   await updateDoc(codeRef, { redeemedBy: uid, redeemedAt: serverTimestamp() })
   await updateDoc(userRef, { referredBy: data.ownerId })
-  await logXpEvent(uid, REFERRAL_XP, 'referral')
+  await logXpEvent(uid, 'creatorReferral')
   return true
 }


### PR DESCRIPTION
## Summary
- update gamification helper to use XP values and new field names
- adjust referrals module to award XP via new utility
- update unit tests for gamification, referrals and abuse modules

## Testing
- `npm test -- --runInBand --ci`

------
https://chatgpt.com/codex/tasks/task_e_6857b9da4b848328bc5b390f91bcbadc