### PR TITLE
Add rank score test

### DIFF
--- a/src/lib/tests/rankScore.test.ts
+++ b/src/lib/tests/rankScore.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { calcRankScore } from '../rank'
+
+describe('calcRankScore', () => {
+  it('Signature creator comfortably outranks Standard', () => {
+    const sig = calcRankScore({
+      tier: 'signature',
+      rating: 4.8,
+      reviews: 35,
+      xp: 2000,
+      responseHrs: 2,
+      proximityKm: 10,
+    })
+    const std = calcRankScore({
+      tier: 'standard',
+      rating: 4.9,
+      reviews: 120,
+      xp: 8000,
+      responseHrs: 2,
+      proximityKm: 10,
+    })
+    expect(sig).toBeGreaterThan(std)
+  })
+})


### PR DESCRIPTION
## Summary
- add a baseline test verifying `calcRankScore`

## Testing
- `pnpm test -t calcRankScore`
- `npm test -- --runInBand --ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857cc4374a88328871c2b824575f07c