### PR TITLE
Task 09 – XP triggers helpers

### DIFF
--- a/functions/src/events/awardXP.ts
+++ b/functions/src/events/awardXP.ts
@@ -1,0 +1,28 @@
+import { logXpEvent } from '../../../src/lib/gamification'
+
+/**
+ * Award XP when a booking is completed.
+ */
+export async function onBookingCompleted(
+  uid: string,
+  bookingId?: string,
+) {
+  await logXpEvent(uid, 'bookingConfirmed', bookingId ? { contextId: bookingId } : {})
+}
+
+/**
+ * Award XP when a 5-star review is created.
+ */
+export async function onReviewCreated(
+  uid: string,
+  reviewId?: string,
+) {
+  await logXpEvent(uid, 'fiveStarReview', reviewId ? { contextId: reviewId } : {})
+}
+
+/**
+ * Award XP for successful referrals.
+ */
+export async function onReferral(uid: string) {
+  await logXpEvent(uid, 'creatorReferral')
+}


### PR DESCRIPTION
## Summary
- add central XP award helpers for firestore triggers

## Testing
- `npm test -- --runInBand --ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859178a8dd083288add26f7bfe99788