### PR TITLE
feat: add post-signup role intent flow

### DIFF
--- a/src/app/select-intent/page.tsx
+++ b/src/app/select-intent/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getAuth } from 'firebase/auth';
+import { setUserIntent } from '@/lib/firestore/setUserIntent';
+import XPProgressBar from '@/components/gamification/XPProgressBar';
+
+export default function SelectIntentPage() {
+  const [intent, setIntent] = useState<'client' | 'provider' | 'both' | ''>('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user || !intent) return;
+    await setUserIntent(user.uid, intent as any);
+    router.push('/dashboard');
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-white flex flex-col items-center justify-center p-8">
+      <h1 className="text-2xl font-bold mb-4 text-center">Welcome! How do you plan to use AuditoryX?</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-sm">
+        <label className="flex items-center gap-2">
+          <input type="radio" value="client" checked={intent==='client'} onChange={() => setIntent('client')} />
+          Book Services (Client)
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="radio" value="provider" checked={intent==='provider'} onChange={() => setIntent('provider')} />
+          Offer Services (Provider)
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="radio" value="both" checked={intent==='both'} onChange={() => setIntent('both')} />
+          Both
+        </label>
+        <button type="submit" disabled={!intent} className="btn btn-primary w-full mt-4">Continue</button>
+      </form>
+      <div className="w-full max-w-sm mt-6">
+        <XPProgressBar currentXP={0} targetXP={50} targetLabel="Apply for Verification" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,7 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { createUserWithEmailAndPassword, getAuth } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { app, db } from '@/lib/firebase';
 import { getRedirectAfterSignup } from './getRedirectAfterSignup';
 
@@ -31,6 +31,10 @@ export default function SignupPage() {
     e.preventDefault();
     try {
       const cred = await createUserWithEmailAndPassword(auth, email, password);
+      await setDoc(doc(db, 'users', cred.user.uid), {
+        email,
+        createdAt: new Date()
+      }, { merge: true });
       
       // Send verification email automatically
       try {
@@ -83,10 +87,10 @@ export default function SignupPage() {
               </button>
               
               <button
-                onClick={() => router.push('/dashboard')}
+                onClick={() => router.push('/select-intent')}
                 className="w-full text-blue-400 hover:text-blue-300 text-sm"
               >
-                Continue to Dashboard →
+                Continue →
               </button>
             </div>
           </div>

--- a/src/components/RoleToggle.tsx
+++ b/src/components/RoleToggle.tsx
@@ -1,38 +1,21 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { getAuth } from 'firebase/auth'
-import { doc, setDoc } from 'firebase/firestore'
-import { db } from '@/lib/firebase'
+import { setUserIntent } from '@/lib/firestore/setUserIntent'
 
-const roles = ['artist', 'producer', 'studio', 'videographer', 'engineer']
+const roles = ['client', 'provider', 'both']
 
 export default function RoleToggle() {
   const [selectedRole, setSelectedRole] = useState('')
-  const [isAdmin, setIsAdmin] = useState(false)
-
-  useEffect(() => {
-    const auth = getAuth()
-    const user = auth.currentUser
-    if (user && user.email === process.env.NEXT_PUBLIC_ADMIN_EMAIL) {
-      setIsAdmin(true)
-    }
-  }, [])
 
   const handleSetRole = async () => {
     const auth = getAuth()
     const user = auth.currentUser
-    if (!user) return alert("No user logged in.")
-    if (!isAdmin) return alert("Unauthorized.")
+    if (!user) return
 
-    await setDoc(doc(db, 'users', user.uid), {
-      role: selectedRole
-    }, { merge: true })
-
-    alert(`Role updated to ${selectedRole}`)
+    await setUserIntent(user.uid, selectedRole as any)
   }
-
-  if (!isAdmin) return null
 
   return (
     <div className="p-4 space-y-2 border rounded">

--- a/src/lib/firestore/setUserIntent.ts
+++ b/src/lib/firestore/setUserIntent.ts
@@ -1,0 +1,6 @@
+import { doc, setDoc } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+
+export async function setUserIntent(uid: string, intent: 'client' | 'provider' | 'both') {
+  await setDoc(doc(db, 'users', uid), { userIntent: intent }, { merge: true });
+}


### PR DESCRIPTION
## Summary
- add `setUserIntent` Firestore helper
- create new `/select-intent` page for post-signup flow
- update signup success button to route to intent selection
- repurpose `RoleToggle` component for client/provider switching

## Testing
- `npm test -- --runInBand --ci` *(fails: jest not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688295fa8a908328b16cb97901969aab